### PR TITLE
Deprecate eigenlayer-bls-local submodule in favor of Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Ignore deprecated submodule
+eigenlayer-bls-local/
+
+# Git files
+.git/
+.gitignore
+
+# Build artifacts
+target/
+*.log
+
+# Environment files
+.env
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "eigenlayer-bls-local"]
-	path = eigenlayer-bls-local
-	url = https://github.com/BreadchainCoop/eigenlayer-bls-local.git
 [submodule "commonware-avs-node"]
 	path = commonware-avs-node
 	url = https://github.com/BreadchainCoop/commonware-avs-node.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  eigenlayer-bls:
+    image: ghcr.io/breadchaincoop/eigenlayer-bls:latest
+    container_name: eigenlayer-bls
+    ports:
+      - "8545:8545"
+    volumes:
+      - ./config:/config
+    environment:
+      - NODE_ENV=development
+      - NUM_OPERATORS=3
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8545"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - avs-network
+
+networks:
+  avs-network:
+    driver: bridge

--- a/example.env
+++ b/example.env
@@ -17,7 +17,8 @@ WS_RPC=wss://ethereum-holesky.publicnode.com # Not a real endpoint
 # =============================================================================
 # Contract Deployment Configuration
 # =============================================================================
-AVS_DEPLOYMENT_PATH="eigenlayer-bls-local/.nodes/avs_deploy.json"
+# For Docker deployment, mount volume or use path inside container
+AVS_DEPLOYMENT_PATH="/config/avs_deploy.json"
 
 # =============================================================================
 # Private Key (Required)
@@ -27,7 +28,8 @@ PRIVATE_KEY=
 # =============================================================================
 # Contributor Key Files
 # =============================================================================
-CONTRIBUTOR_1_KEYFILE="../eigenlayer-bls-local/.nodes/operator_keys/testacc1.private.bls.key.json"
-CONTRIBUTOR_2_KEYFILE="../eigenlayer-bls-local/.nodes/operator_keys/testacc2.private.bls.key.json"
-CONTRIBUTOR_3_KEYFILE="../eigenlayer-bls-local/.nodes/operator_keys/testacc3.private.bls.key.json"
+# For Docker deployment, mount volumes or use paths inside container
+CONTRIBUTOR_1_KEYFILE="/config/operator_keys/testacc1.private.bls.key.json"
+CONTRIBUTOR_2_KEYFILE="/config/operator_keys/testacc2.private.bls.key.json"
+CONTRIBUTOR_3_KEYFILE="/config/operator_keys/testacc3.private.bls.key.json"
 INGRESS=false


### PR DESCRIPTION
## Summary
- Removes the `eigenlayer-bls-local` git submodule
- Replaces submodule functionality with Docker images from CI/CD pipeline
- Adds docker-compose.yml for easy local deployment

## Changes
- **Removed eigenlayer-bls-local submodule** from git and .gitmodules
- **Updated example.env** to use Docker volume paths (`/config/...`) instead of submodule paths
- **Created docker-compose.yml** for one-command deployment
- **Updated README.md** with:
  - Docker image documentation
  - Migration guide for users upgrading from submodule version
  - Updated setup instructions using Docker
- **Added .dockerignore** to prevent including deprecated directories

## Test Plan
- [ ] Verify docker-compose up successfully starts the EigenLayer BLS environment
- [ ] Confirm config files and keys are properly mounted to /config volume
- [ ] Test that the AVS router can connect using the new paths
- [ ] Validate that existing functionality remains intact

## Migration Guide
Users upgrading from the submodule version should:
1. Remove old submodule: `rm -rf eigenlayer-bls-local`
2. Update `.env` file with new paths (see example.env)
3. Run `docker-compose up -d` instead of submodule initialization
4. Find config files in `./config` instead of `eigenlayer-bls-local/.nodes`

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)