### PR TITLE
Refactor Creator and ListeningCreator to Extend Common Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -290,7 +290,7 @@ dependencies = [
  "alloy-transport 0.9.2",
  "futures",
  "futures-util",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
  "alloy-transport 0.12.6",
  "futures",
  "futures-util",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -355,7 +355,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -403,7 +403,7 @@ dependencies = [
  "alloy-rlp",
  "k256",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -555,7 +555,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -569,7 +569,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -583,7 +583,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -630,7 +630,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -655,7 +655,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -681,7 +681,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -748,7 +748,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "indexmap 2.10.0",
  "itoa",
  "k256",
@@ -789,7 +789,7 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "schnellru",
  "serde",
  "serde_json",
@@ -826,11 +826,11 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "url",
@@ -866,11 +866,11 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "url",
@@ -911,10 +911,10 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "url",
@@ -978,7 +978,7 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -993,7 +993,7 @@ dependencies = [
  "alloy-transport-http 0.5.4",
  "futures",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1016,7 +1016,7 @@ dependencies = [
  "alloy-transport-http 0.8.3",
  "futures",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1042,7 +1042,7 @@ dependencies = [
  "alloy-transport-ws 0.9.2",
  "futures",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1069,7 +1069,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1254,7 +1254,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1274,7 +1274,7 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1288,7 +1288,7 @@ dependencies = [
  "alloy-serde 0.12.6",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1386,7 +1386,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1401,7 +1401,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1418,7 +1418,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -1436,7 +1436,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -1453,7 +1453,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1469,7 +1469,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1483,7 +1483,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1500,7 +1500,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -1519,7 +1519,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
  "syn-solidity",
 ]
 
@@ -1578,7 +1578,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -1598,7 +1598,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -1620,7 +1620,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -1636,7 +1636,7 @@ checksum = "91fd1a5d0827939847983b46f2f79510361f901dc82f8e3c38ac7397af142c6e"
 dependencies = [
  "alloy-json-rpc 0.5.4",
  "alloy-transport 0.5.4",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1651,7 +1651,7 @@ checksum = "2ed40eb1e1265b2911512f6aa1dcece9702d078f5a646730c45e39e2be00ac1c"
 dependencies = [
  "alloy-json-rpc 0.8.3",
  "alloy-transport 0.8.3",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1666,7 +1666,7 @@ checksum = "6e1509599021330a31c4a6816b655e34bf67acb1cc03c564e09fd8754ff6c5de"
 dependencies = [
  "alloy-json-rpc 0.9.2",
  "alloy-transport 0.9.2",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1681,7 +1681,7 @@ checksum = "a082c9473c6642cce8b02405a979496126a03b096997888e86229afad05db06c"
 dependencies = [
  "alloy-json-rpc 0.12.6",
  "alloy-transport 0.12.6",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1737,7 +1737,7 @@ dependencies = [
  "alloy-transport 0.9.2",
  "futures",
  "http 1.3.1",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.24.0",
@@ -1755,7 +1755,7 @@ dependencies = [
  "alloy-transport 0.12.6",
  "futures",
  "http 1.3.1",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -1802,9 +1802,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1832,29 +1832,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "ark-bn254"
@@ -1881,7 +1881,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -1974,7 +1974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2012,7 +2012,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2027,7 +2027,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2101,7 +2101,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2160,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -2188,7 +2188,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2199,7 +2199,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2227,7 +2227,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2238,9 +2238,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
+checksum = "1541072f81945fa1251f8795ef6c92c4282d74d59f88498ae7d4bf00f0ebdad9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -2250,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.9"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
+checksum = "c034a1bc1d70e16e7f4e4caf7e9f7693e4c9c24cd91cf17c2a0b21abaebc7c8b"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -2269,14 +2269,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.17.0",
+ "uuid 1.18.0",
 ]
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.79.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5603bd5e0487e90acdef4a9be019f55c841e8eb72d3cb2e88c1c112c67a59db"
+checksum = "51e4bd98d45d4bd2e9b8778d0d99cd64e62367bbbb19516248edd9613574436c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2296,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -2329,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.2"
+version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
+checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2367,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.4"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
+checksum = "9e107ce0783019dbff59b3a244aa0c114e4a8c9d93498af9162608cd5474e796"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.3"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852b9226cb60b78ce9369022c0df678af1cac231c882d5da97a0c4e03be6e67"
+checksum = "75d52251ed4b9776a3e8487b2a01ac915f73b2da3af8fc1e77e0fce697a550d4"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -2430,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2816,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
 dependencies = [
  "serde",
 ]
@@ -2854,9 +2854,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -2952,18 +2952,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3073,7 +3073,7 @@ dependencies = [
  "prometheus-client 0.23.1",
  "prost",
  "prost-build",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3093,7 +3093,7 @@ checksum = "7c1495b0aef5282425702984c382ab7499bb4b4b4b03f68702b55f1a9e330253"
 dependencies = [
  "bytes",
  "paste",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -3113,7 +3113,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "sha2 0.10.9",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "zeroize",
 ]
 
@@ -3141,7 +3141,7 @@ dependencies = [
  "eigen-types",
  "eigen-utils 0.1.3",
  "eyre",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "tokio",
@@ -3183,7 +3183,7 @@ dependencies = [
  "prometheus-client 0.22.3",
  "rand 0.8.5",
  "rand_distr",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -3211,7 +3211,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "sha2 0.10.9",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -3234,7 +3234,7 @@ dependencies = [
  "futures",
  "hkdf",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "x25519-dalek",
  "zeroize",
 ]
@@ -3250,7 +3250,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -3460,7 +3460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3495,7 +3495,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3532,7 +3532,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3543,7 +3543,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3637,7 +3637,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "unicode-xid",
 ]
 
@@ -3649,7 +3649,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "unicode-xid",
 ]
 
@@ -3724,7 +3724,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3753,9 +3753,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -3796,7 +3796,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4009,7 +4009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640db3098ff0d359ce9292e7a3a8ae7ef3d72817e0d5c4f0cc759ed0879661b3"
 dependencies = [
  "alloy 0.9.2",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
 ]
 
 [[package]]
@@ -4020,7 +4020,7 @@ checksum = "0813ece83d4e9c95eddad48bf6cbfe2e1c083ffbd9eac87a40d818225be31db0"
 dependencies = [
  "alloy 0.12.6",
  "regex",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
 ]
 
 [[package]]
@@ -4106,7 +4106,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4261,7 +4261,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
  "toml",
  "walkdir",
 ]
@@ -4279,7 +4279,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4305,7 +4305,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.104",
+ "syn 2.0.105",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -4445,9 +4445,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -4670,7 +4670,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4774,9 +4774,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -4842,9 +4842,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4889,9 +4889,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -5041,7 +5041,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5057,7 +5057,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.11",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5092,7 +5092,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -5118,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5134,7 +5134,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -5314,14 +5314,14 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -5341,7 +5341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -5380,9 +5380,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -5570,9 +5570,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -5582,9 +5582,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -5624,7 +5624,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5633,7 +5633,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5650,7 +5650,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5832,7 +5832,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5929,7 +5929,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5960,7 +5960,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -5974,7 +5974,7 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "opentelemetry",
- "reqwest 0.12.22",
+ "reqwest 0.12.23",
  "tracing",
 ]
 
@@ -5992,8 +5992,8 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.22",
- "thiserror 2.0.12",
+ "reqwest 0.12.23",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -6024,7 +6024,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6085,7 +6085,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6204,7 +6204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "ucd-trie",
 ]
 
@@ -6268,7 +6268,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6297,7 +6297,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6405,12 +6405,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6464,14 +6464,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -6508,7 +6508,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6522,7 +6522,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -6557,7 +6557,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.105",
  "tempfile",
 ]
 
@@ -6571,7 +6571,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6616,9 +6616,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.29",
- "socket2",
- "thiserror 2.0.12",
+ "rustls 0.23.31",
+ "socket2 0.5.10",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "web-time",
@@ -6633,13 +6633,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6654,7 +6654,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6694,9 +6694,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -6770,9 +6770,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -6780,9 +6780,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -6796,9 +6796,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.14"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -6831,7 +6831,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6927,9 +6927,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6937,7 +6937,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.11",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -6952,7 +6952,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7043,9 +7043,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -7060,7 +7060,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rlp",
  "ruint-macro",
  "serde",
@@ -7104,9 +7104,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -7165,9 +7165,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring 0.17.14",
@@ -7219,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -7280,7 +7280,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7461,14 +7461,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -7536,7 +7536,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7634,9 +7634,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -7659,7 +7659,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "time",
 ]
 
@@ -7671,9 +7671,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -7692,6 +7692,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7791,7 +7801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7803,7 +7813,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7851,9 +7861,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7869,7 +7879,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7895,7 +7905,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7981,11 +7991,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -7996,18 +8006,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8105,9 +8115,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8118,9 +8128,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8131,7 +8141,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8160,7 +8170,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -8199,7 +8209,7 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -8215,7 +8225,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -8225,9 +8235,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8391,7 +8401,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8524,7 +8534,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -8542,11 +8552,11 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.1",
- "rustls 0.23.29",
+ "rand 0.9.2",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "utf-8",
 ]
 
@@ -8671,9 +8681,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8768,7 +8778,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -8803,7 +8813,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8947,7 +8957,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8958,7 +8968,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9029,7 +9039,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -9065,10 +9075,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -9264,7 +9275,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -9317,7 +9328,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure",
 ]
 
@@ -9338,7 +9349,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9358,7 +9369,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure",
 ]
 
@@ -9379,7 +9390,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9395,9 +9406,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9412,7 +9423,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]

--- a/scripts/Cargo.lock
+++ b/scripts/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "28e2652684758b0d9b389d248b209ed9fd9989ef489a550265fe4bb8454fe7eb"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -227,7 +227,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -290,7 +290,7 @@ dependencies = [
  "alloy-transport 0.9.2",
  "futures",
  "futures-util",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
  "alloy-transport 0.12.6",
  "futures",
  "futures-util",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -355,7 +355,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -403,7 +403,7 @@ dependencies = [
  "alloy-rlp",
  "k256",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -555,7 +555,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -569,7 +569,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -583,7 +583,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -630,7 +630,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -655,7 +655,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -681,7 +681,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -748,8 +748,8 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.10.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -789,7 +789,7 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "schnellru",
  "serde",
  "serde_json",
@@ -826,11 +826,11 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "url",
@@ -866,11 +866,11 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "url",
@@ -911,10 +911,10 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "url",
@@ -978,7 +978,7 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -993,7 +993,7 @@ dependencies = [
  "alloy-transport-http 0.5.4",
  "futures",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1016,7 +1016,7 @@ dependencies = [
  "alloy-transport-http 0.8.3",
  "futures",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1042,7 +1042,7 @@ dependencies = [
  "alloy-transport-ws 0.9.2",
  "futures",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1069,7 +1069,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1195,7 +1195,7 @@ dependencies = [
  "derive_more 2.0.1",
  "rand 0.8.5",
  "serde",
- "strum 0.27.1",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -1254,7 +1254,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1274,7 +1274,7 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1288,7 +1288,7 @@ dependencies = [
  "alloy-serde 0.12.6",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1372,7 +1372,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1386,7 +1386,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1401,7 +1401,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1418,7 +1418,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -1436,7 +1436,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -1453,7 +1453,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1469,7 +1469,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -1483,7 +1483,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1496,11 +1496,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -1519,7 +1519,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
  "syn-solidity",
 ]
 
@@ -1578,7 +1578,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -1598,7 +1598,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -1620,7 +1620,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -1636,7 +1636,7 @@ checksum = "91fd1a5d0827939847983b46f2f79510361f901dc82f8e3c38ac7397af142c6e"
 dependencies = [
  "alloy-json-rpc 0.5.4",
  "alloy-transport 0.5.4",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1651,7 +1651,7 @@ checksum = "2ed40eb1e1265b2911512f6aa1dcece9702d078f5a646730c45e39e2be00ac1c"
 dependencies = [
  "alloy-json-rpc 0.8.3",
  "alloy-transport 0.8.3",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1666,7 +1666,7 @@ checksum = "6e1509599021330a31c4a6816b655e34bf67acb1cc03c564e09fd8754ff6c5de"
 dependencies = [
  "alloy-json-rpc 0.9.2",
  "alloy-transport 0.9.2",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1681,7 +1681,7 @@ checksum = "a082c9473c6642cce8b02405a979496126a03b096997888e86229afad05db06c"
 dependencies = [
  "alloy-json-rpc 0.12.6",
  "alloy-transport 0.12.6",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1737,7 +1737,7 @@ dependencies = [
  "alloy-transport 0.9.2",
  "futures",
  "http 1.3.1",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.24.0",
@@ -1755,7 +1755,7 @@ dependencies = [
  "alloy-transport 0.12.6",
  "futures",
  "http 1.3.1",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -1802,9 +1802,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1832,29 +1832,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "ark-bn254"
@@ -1881,7 +1881,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -1974,7 +1974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2012,7 +2012,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2027,7 +2027,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2101,7 +2101,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2160,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -2188,7 +2188,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2199,7 +2199,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2227,7 +2227,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "1541072f81945fa1251f8795ef6c92c4282d74d59f88498ae7d4bf00f0ebdad9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -2263,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.8"
+version = "1.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
+checksum = "c034a1bc1d70e16e7f4e4caf7e9f7693e4c9c24cd91cf17c2a0b21abaebc7c8b"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -2282,14 +2282,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.17.0",
+ "uuid 1.18.0",
 ]
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.76.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8565497721d9f18fa29a68bc5d8225b39e1cc7399d7fc6f1ad803ca934341804"
+checksum = "51e4bd98d45d4bd2e9b8778d0d99cd64e62367bbbb19516248edd9613574436c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2309,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -2342,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -2380,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.3"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+checksum = "9e107ce0783019dbff59b3a244aa0c114e4a8c9d93498af9162608cd5474e796"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -2403,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.1"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
+checksum = "75d52251ed4b9776a3e8487b2a01ac915f73b2da3af8fc1e77e0fce697a550d4"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -2443,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.7"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+checksum = "b069d19bf01e46298eaedd7c6f283fe565a59263e53eebec945f3e6398f42390"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2731,16 +2731,16 @@ dependencies = [
 [[package]]
 name = "bn254"
 version = "0.1.3"
-source = "git+https://github.com/BreadchainCoop/bn254.git#fd0a22a0af16cd9d8efdd435171abad35cf4c5b5"
+source = "git+https://github.com/BreadchainCoop/bn254.git#8e8b32a5899707b04ce53e7f1a096213589d504c"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytes",
- "commonware-codec 0.0.50",
- "commonware-cryptography 0.0.50",
- "commonware-utils 0.0.50",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-utils",
  "eigen-crypto-bn254 0.5.0",
  "rand 0.8.5",
 ]
@@ -2757,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2829,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
 dependencies = [
  "serde",
 ]
@@ -2867,9 +2867,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -2965,18 +2965,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3067,13 +3067,13 @@ dependencies = [
  "bn254",
  "bytes",
  "clap",
- "commonware-codec 0.0.56",
- "commonware-cryptography 0.0.56",
+ "commonware-codec",
+ "commonware-cryptography",
  "commonware-eigenlayer",
  "commonware-macros",
  "commonware-p2p",
  "commonware-runtime",
- "commonware-utils 0.0.56",
+ "commonware-utils",
  "dotenv",
  "eigen-crypto-bls 0.5.0",
  "eigen-crypto-bn254 0.5.0",
@@ -3086,7 +3086,7 @@ dependencies = [
  "prometheus-client 0.23.1",
  "prost",
  "prost-build",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3100,44 +3100,13 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "0.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff0994a50e73a8b8738020614340a25df5edf8b3b1b0b874b5ec8c60295e44"
-dependencies = [
- "bytes",
- "paste",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "commonware-codec"
 version = "0.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c1495b0aef5282425702984c382ab7499bb4b4b4b03f68702b55f1a9e330253"
 dependencies = [
  "bytes",
  "paste",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "commonware-cryptography"
-version = "0.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ade135f1071a9bfb71fc4d3788b91a572bccc26341eaf90d45fe376d5709f0"
-dependencies = [
- "blst",
- "bytes",
- "commonware-codec 0.0.50",
- "commonware-utils 0.0.50",
- "ed25519-consensus",
- "getrandom 0.2.16",
- "p256",
- "rand 0.8.5",
- "rayon",
- "sha2 0.10.9",
- "thiserror 2.0.12",
- "zeroize",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -3149,22 +3118,22 @@ dependencies = [
  "blake3",
  "blst",
  "bytes",
- "commonware-codec 0.0.56",
- "commonware-utils 0.0.56",
+ "commonware-codec",
+ "commonware-utils",
  "ed25519-consensus",
  "getrandom 0.2.16",
  "p256",
  "rand 0.8.5",
  "rayon",
  "sha2 0.10.9",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "zeroize",
 ]
 
 [[package]]
 name = "commonware-eigenlayer"
 version = "0.1.0"
-source = "git+https://github.com/BreadchainCoop/commonware-avs-network-lookup#a6a3385a16e581f5d81450a984db3c064cbf1843"
+source = "git+https://github.com/BreadchainCoop/commonware-avs-network-lookup#a76cb2f9b619001ec48eaf299cfd1a80fe08b50c"
 dependencies = [
  "alloy 0.8.3",
  "alloy-network 0.5.4",
@@ -3185,7 +3154,7 @@ dependencies = [
  "eigen-types",
  "eigen-utils 0.1.3",
  "eyre",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "tokio",
@@ -3215,19 +3184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f063844f8b90519e9b7b1b0e29a97c825cbe2df59e0a222e506d55a9243c020"
 dependencies = [
  "bytes",
- "commonware-codec 0.0.56",
- "commonware-cryptography 0.0.56",
+ "commonware-codec",
+ "commonware-cryptography",
  "commonware-macros",
  "commonware-runtime",
  "commonware-stream",
- "commonware-utils 0.0.56",
+ "commonware-utils",
  "either",
  "futures",
  "governor",
  "prometheus-client 0.22.3",
  "rand 0.8.5",
  "rand_distr",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -3242,7 +3211,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "commonware-macros",
- "commonware-utils 0.0.56",
+ "commonware-utils",
  "criterion",
  "futures",
  "getrandom 0.2.16",
@@ -3255,7 +3224,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "sha2 0.10.9",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -3270,29 +3239,17 @@ checksum = "cddd40df46f56a2beafdc9658d395639c15d4c2483e05c73110622763ca082b4"
 dependencies = [
  "bytes",
  "chacha20poly1305",
- "commonware-codec 0.0.56",
- "commonware-cryptography 0.0.56",
+ "commonware-codec",
+ "commonware-cryptography",
  "commonware-macros",
  "commonware-runtime",
- "commonware-utils 0.0.56",
+ "commonware-utils",
  "futures",
  "hkdf",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "x25519-dalek",
  "zeroize",
-]
-
-[[package]]
-name = "commonware-utils"
-version = "0.0.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8e3b8335c6030fd138a0d99a0f40990ab0b657c14f7fcd86f5b353f32ac38c"
-dependencies = [
- "bytes",
- "commonware-codec 0.0.50",
- "futures",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3302,11 +3259,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a54dfd09f06c05634bfad9c7f9a1218d085c96b87db0d6c6d39c06dc30c91af4"
 dependencies = [
  "bytes",
- "commonware-codec 0.0.56",
+ "commonware-codec",
  "futures",
  "getrandom 0.2.16",
  "rand 0.8.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -3411,9 +3368,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -3482,9 +3439,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -3516,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3551,7 +3508,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3588,7 +3545,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3599,7 +3556,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3693,7 +3650,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "unicode-xid",
 ]
 
@@ -3705,7 +3662,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "unicode-xid",
 ]
 
@@ -3780,7 +3737,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3809,9 +3766,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -3852,7 +3809,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4065,7 +4022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640db3098ff0d359ce9292e7a3a8ae7ef3d72817e0d5c4f0cc759ed0879661b3"
 dependencies = [
  "alloy 0.9.2",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
 ]
 
 [[package]]
@@ -4076,7 +4033,7 @@ checksum = "0813ece83d4e9c95eddad48bf6cbfe2e1c083ffbd9eac87a40d818225be31db0"
 dependencies = [
  "alloy 0.12.6",
  "regex",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
 ]
 
 [[package]]
@@ -4162,7 +4119,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4317,7 +4274,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
  "toml",
  "walkdir",
 ]
@@ -4335,7 +4292,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4361,7 +4318,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.104",
+ "syn 2.0.105",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -4501,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -4591,6 +4548,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -4720,7 +4683,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4824,9 +4787,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gloo-timers"
@@ -4873,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -4883,7 +4846,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4892,9 +4855,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4902,7 +4865,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4939,9 +4902,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -5084,14 +5047,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5107,7 +5070,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5142,12 +5105,12 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -5168,9 +5131,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5184,7 +5147,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -5364,14 +5327,14 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -5386,12 +5349,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -5426,6 +5389,17 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -5582,7 +5556,7 @@ dependencies = [
  "ena",
  "itertools 0.11.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.6.5",
  "regex",
  "regex-syntax 0.8.5",
  "string_cache",
@@ -5609,9 +5583,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -5621,9 +5595,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -5663,7 +5637,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5672,7 +5646,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5689,7 +5663,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5871,7 +5845,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5968,7 +5942,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -5999,7 +5973,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -6013,7 +5987,7 @@ dependencies = [
  "bytes",
  "http 1.3.1",
  "opentelemetry",
- "reqwest 0.12.20",
+ "reqwest 0.12.23",
  "tracing",
 ]
 
@@ -6031,8 +6005,8 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.20",
- "thiserror 2.0.12",
+ "reqwest 0.12.23",
+ "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -6063,7 +6037,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6124,7 +6098,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6243,7 +6217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "ucd-trie",
 ]
 
@@ -6253,8 +6227,18 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
- "indexmap 2.9.0",
+ "fixedbitset 0.4.2",
+ "indexmap 2.10.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -6297,7 +6281,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6326,7 +6310,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6434,12 +6418,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6493,14 +6477,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -6537,7 +6521,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6551,7 +6535,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -6581,12 +6565,12 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.105",
  "tempfile",
 ]
 
@@ -6600,7 +6584,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6645,9 +6629,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.28",
- "socket2",
- "thiserror 2.0.12",
+ "rustls 0.23.31",
+ "socket2 0.5.10",
+ "thiserror 2.0.14",
  "tokio",
  "tracing",
  "web-time",
@@ -6662,13 +6646,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6683,7 +6667,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -6723,9 +6707,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -6799,9 +6783,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -6809,9 +6793,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -6825,9 +6809,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -6860,7 +6844,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -6924,7 +6908,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -6956,9 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6966,7 +6950,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -6981,7 +6965,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6997,7 +6981,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -7072,9 +7056,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -7089,7 +7073,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rlp",
  "ruint-macro",
  "serde",
@@ -7133,9 +7117,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -7169,15 +7153,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7194,14 +7178,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -7237,9 +7221,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -7248,9 +7232,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -7309,7 +7293,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7326,6 +7310,18 @@ name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7478,14 +7474,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -7526,16 +7522,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
- "schemars",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7545,14 +7542,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7561,7 +7558,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -7650,9 +7647,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -7675,7 +7672,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "time",
 ]
 
@@ -7687,9 +7684,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -7708,6 +7705,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7790,11 +7797,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.1",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -7807,20 +7814,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7868,9 +7874,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7886,7 +7892,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7912,7 +7918,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -7998,11 +8004,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -8013,18 +8019,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8122,20 +8128,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8146,7 +8154,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8175,7 +8183,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -8214,7 +8222,7 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -8230,7 +8238,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -8240,9 +8248,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -8278,7 +8286,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8406,7 +8414,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8539,7 +8547,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.28",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -8557,11 +8565,11 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.1",
- "rustls 0.23.28",
+ "rand 0.9.2",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "utf-8",
 ]
 
@@ -8686,9 +8694,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8783,7 +8791,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -8818,7 +8826,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8892,14 +8900,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8962,7 +8970,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8973,7 +8981,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -8984,9 +8992,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -9044,7 +9052,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -9080,10 +9088,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -9234,9 +9243,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -9279,7 +9288,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -9332,7 +9341,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure",
 ]
 
@@ -9353,7 +9362,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9373,7 +9382,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure",
 ]
 
@@ -9394,7 +9403,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9410,9 +9419,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9427,7 +9436,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]

--- a/scripts/verify_increments.rs
+++ b/scripts/verify_increments.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Initial counter value: {}", initial_count);
     
     let target_increments = 2;
-    let max_wait_time = Duration::from_secs(150); // 2.5 minutes max wait
+    let max_wait_time = Duration::from_secs(300); // 2.5 minutes max wait
     let check_interval = Duration::from_secs(10);  // Check every 10 seconds
     
     let start_time = std::time::Instant::now();

--- a/scripts/verify_increments.rs
+++ b/scripts/verify_increments.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Initial counter value: {}", initial_count);
     
     let target_increments = 2;
-    let max_wait_time = Duration::from_secs(300); // 2.5 minutes max wait
+    let max_wait_time = Duration::from_secs(300); // 5 minutes max wait
     let check_interval = Duration::from_secs(10);  // Check every 10 seconds
     
     let start_time = std::time::Instant::now();

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -28,3 +28,30 @@ pub mod blssigcheckoperatorstateretriever;
     dead_code
 )]
 pub mod counter;
+
+use alloy::{network::EthereumWallet, providers::fillers::FillProvider};
+use alloy_provider::{
+    RootProvider,
+    fillers::{BlobGasFiller, ChainIdFiller, GasFiller, JoinFill, NonceFiller, WalletFiller},
+};
+
+// Type alias for provider with wallet capabilities (for transactions)
+pub type WalletProvider = FillProvider<
+    JoinFill<
+        JoinFill<
+            alloy_provider::Identity,
+            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+        >,
+        WalletFiller<EthereumWallet>,
+    >,
+    RootProvider,
+>;
+
+// Type alias for read-only provider (without wallet, for queries)
+pub type ReadOnlyProvider = FillProvider<
+    JoinFill<
+        alloy_provider::Identity,
+        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+    >,
+    RootProvider,
+>;

--- a/src/creator/base.rs
+++ b/src/creator/base.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+
+/// Trait defining the interface for contract provider implementations.
+///
+/// This trait provides a generic interface for contract interactions,
+/// allowing different contract implementations to be swapped without changing
+/// the consuming code. Each implementation can define its own state type
+/// through the associated `State` type.
+#[async_trait::async_trait]
+pub trait ContractProviderTrait: Send + Sync {
+    /// The state type returned by this contract provider.
+    ///
+    /// This can be any type that represents the current state of the contract.
+    /// For simple contracts, this might be a number (u64, u32, etc.).
+    /// For complex contracts, this could be a struct or enum.
+    /// The state type must implement Debug for logging purposes.
+    /// The state type must also be Send + Sync for async operations.
+    type State: std::fmt::Debug + Send + Sync;
+
+    /// Gets the current state from the contract.
+    ///
+    /// This method retrieves the current state value from the underlying contract.
+    /// The exact meaning of "state" depends on the contract implementation.
+    ///
+    /// # Returns
+    /// * `Result<Self::State>` - The current state value, or an error
+    async fn get_current_state(&self) -> Result<Self::State>;
+
+    /// Encodes a state value for contract interaction.
+    ///
+    /// This method encodes a state value into the format expected by the contract.
+    /// The encoding format depends on the contract's ABI.
+    ///
+    /// # Arguments
+    /// * `state` - The state value to encode
+    ///
+    /// # Returns
+    /// * `Vec<u8>` - The encoded state data
+    async fn encode_state_call(&self, state: &Self::State) -> Vec<u8>;
+}
+
+/// Base implementation for creators that use contract providers.
+///
+/// This struct provides common functionality for creators that need to interact
+/// with contracts through a provider interface.
+pub struct BaseCreator<P: ContractProviderTrait> {
+    contract_provider: P,
+}
+
+impl<P: ContractProviderTrait> BaseCreator<P> {
+    /// Creates a new BaseCreator with the given contract provider.
+    pub fn new(contract_provider: P) -> Self {
+        Self { contract_provider }
+    }
+
+    /// Gets the current state from the contract provider.
+    pub async fn get_current_state(&self) -> Result<P::State> {
+        self.contract_provider.get_current_state().await
+    }
+
+    /// Encodes a state call using the contract provider.
+    pub async fn encode_state_call(&self, state: &P::State) -> Vec<u8> {
+        self.contract_provider.encode_state_call(state).await
+    }
+
+    /// Gets task data with the current state.
+    #[allow(dead_code)] // Kept for binary target, used in tests
+    pub async fn get_task_data(&self) -> Result<crate::creator::types::TaskData> {
+        let _current_state = self.get_current_state().await?;
+        Ok(crate::creator::types::TaskData::default())
+    }
+}

--- a/src/creator/implementations/default.rs
+++ b/src/creator/implementations/default.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+
+use crate::creator::{base::BaseCreator, interface::TaskCreatorTrait, types::TaskData};
+
+use super::super::base::ContractProviderTrait;
+
+/// Default creator implementation that uses default task data.
+///
+/// This creator is generic over the contract provider's state type,
+/// allowing it to work with any contract provider implementation.
+pub struct Creator<P: ContractProviderTrait> {
+    base: BaseCreator<P>,
+}
+
+impl<P: ContractProviderTrait> Creator<P> {
+    pub fn new(contract_provider: P) -> Self {
+        let base = BaseCreator::new(contract_provider);
+        Self { base }
+    }
+
+    async fn get_payload_and_state(&self) -> Result<(Vec<u8>, P::State)> {
+        let current_state = self.get_current_state().await?;
+        let encoded_state = self.base.encode_state_call(&current_state).await;
+        let task_data = self.get_task_data().await?;
+        let payload = task_data.encode_into_payload(encoded_state);
+        Ok((payload, current_state))
+    }
+
+    async fn get_task_data(&self) -> Result<TaskData> {
+        Ok(TaskData::default())
+    }
+}
+
+#[async_trait::async_trait]
+impl<P: ContractProviderTrait> TaskCreatorTrait<P::State> for Creator<P> {
+    async fn get_payload_and_state(&self) -> anyhow::Result<(Vec<u8>, P::State)> {
+        self.get_payload_and_state()
+            .await
+            .map_err(|e| anyhow::anyhow!("Creator error: {}", e))
+    }
+
+    async fn get_current_state(&self) -> anyhow::Result<P::State> {
+        self.base.get_current_state().await
+    }
+}

--- a/src/creator/implementations/listening.rs
+++ b/src/creator/implementations/listening.rs
@@ -1,0 +1,78 @@
+use tracing::info;
+
+use crate::creator::{
+    base::BaseCreator, interface::TaskCreatorTrait, types::TaskData, types::TaskQueue,
+};
+use crate::ingress::TaskRequest;
+
+use super::super::base::ContractProviderTrait;
+
+/// Listening creator implementation that uses a task queue.
+///
+/// This creator is generic over the contract provider's state type and queue type,
+/// allowing it to work with any contract provider and queue implementation.
+pub struct ListeningCreator<P: ContractProviderTrait, Q: TaskQueue> {
+    base: BaseCreator<P>,
+    pub queue: Q,
+}
+
+impl<P: ContractProviderTrait, Q: TaskQueue> ListeningCreator<P, Q> {
+    pub fn new(contract_provider: P, queue: Q) -> Self {
+        let base = BaseCreator::new(contract_provider);
+        Self { base, queue }
+    }
+
+    // Pulls the next task from the queue, or returns None if empty
+    pub async fn get_next_task(&self) -> Option<TaskRequest> {
+        self.queue.pop()
+    }
+
+    // Single entry point that can be called by the orchestrator
+    // This is where queue requests would be pulled from
+    pub async fn get_payload_and_state(&self) -> anyhow::Result<(Vec<u8>, P::State)> {
+        // Wait for a task to be available
+        let task = loop {
+            if let Some(task) = self.get_next_task().await {
+                break task;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        };
+        let current_state = self.get_current_state().await?;
+        let encoded_state = self.base.encode_state_call(&current_state).await;
+        let task_data = self.get_task_data(task).await?;
+        let payload = task_data.encode_into_payload(encoded_state);
+        Ok((payload, current_state))
+    }
+
+    // Optional: Method to get payload for a specific state
+    #[allow(dead_code)]
+    pub async fn get_payload_for_state(
+        &self,
+        state: P::State,
+    ) -> anyhow::Result<(Vec<u8>, P::State)> {
+        let payload = self.base.encode_state_call(&state).await;
+        info!("Created payload for specific state: {:?}", state);
+        Ok((payload, state))
+    }
+
+    async fn get_task_data(&self, task: TaskRequest) -> anyhow::Result<TaskData> {
+        Ok(TaskData::new(
+            task.body.var1,
+            task.body.var2,
+            task.body.var3,
+        ))
+    }
+}
+
+#[async_trait::async_trait]
+impl<P: ContractProviderTrait, Q: TaskQueue> TaskCreatorTrait<P::State> for ListeningCreator<P, Q> {
+    async fn get_payload_and_state(&self) -> anyhow::Result<(Vec<u8>, P::State)> {
+        self.get_payload_and_state()
+            .await
+            .map_err(|e| anyhow::anyhow!("ListeningCreator error: {}", e))
+    }
+
+    async fn get_current_state(&self) -> anyhow::Result<P::State> {
+        self.base.get_current_state().await
+    }
+}

--- a/src/creator/implementations/mod.rs
+++ b/src/creator/implementations/mod.rs
@@ -1,0 +1,3 @@
+pub mod default;
+pub mod listening;
+pub mod queue;

--- a/src/creator/implementations/queue.rs
+++ b/src/creator/implementations/queue.rs
@@ -1,0 +1,47 @@
+use std::sync::{Arc, Mutex};
+
+use crate::creator::types::TaskQueue;
+use crate::ingress::TaskRequest;
+
+/// Simplified concrete implementation of TaskQueue using std::sync::Mutex
+///
+/// This is a basic, working implementation that uses a Vec as the underlying storage
+/// with standard mutex synchronization. It's simpler and more reliable than the
+/// previous async implementation.
+pub struct SimpleTaskQueue {
+    queue: Arc<Mutex<Vec<TaskRequest>>>,
+}
+
+impl SimpleTaskQueue {
+    pub fn new() -> Self {
+        Self {
+            queue: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn get_queue(&self) -> Arc<Mutex<Vec<TaskRequest>>> {
+        self.queue.clone()
+    }
+}
+
+impl Default for SimpleTaskQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskQueue for SimpleTaskQueue {
+    fn push(&self, task: TaskRequest) {
+        if let Ok(mut queue) = self.queue.lock() {
+            queue.push(task);
+        }
+    }
+
+    fn pop(&self) -> Option<TaskRequest> {
+        if let Ok(mut queue) = self.queue.lock() {
+            queue.pop()
+        } else {
+            None
+        }
+    }
+}

--- a/src/creator/interface.rs
+++ b/src/creator/interface.rs
@@ -1,0 +1,25 @@
+/// Shared trait for creators that can generate payloads and state.
+///
+/// This trait is generic over the state type, allowing different contract
+/// providers to return different state types while maintaining a consistent
+/// interface for payload generation.
+#[async_trait::async_trait]
+pub trait TaskCreatorTrait<State = u64>: Send + Sync {
+    /// Get the current payload and state.
+    ///
+    /// This method generates a payload based on the current state and returns
+    /// both the payload and the current state value.
+    ///
+    /// # Returns
+    /// * `Result<(Vec<u8>, State)>` - The payload and current state, or an error
+    async fn get_payload_and_state(&self) -> anyhow::Result<(Vec<u8>, State)>;
+
+    /// Get the current onchain state.
+    ///
+    /// This method retrieves the current state value from the underlying
+    /// contract provider.
+    ///
+    /// # Returns
+    /// * `Result<State>` - The current state value, or an error
+    async fn get_current_state(&self) -> anyhow::Result<State>;
+}

--- a/src/creator/mod.rs
+++ b/src/creator/mod.rs
@@ -3,6 +3,10 @@ pub mod implementations;
 pub mod interface;
 pub mod types;
 
+// Test module (only compiled in test mode)
+#[cfg(test)]
+pub mod tests;
+
 // Re-export main types and traits
 pub use implementations::{default::Creator, listening::ListeningCreator, queue::SimpleTaskQueue};
 pub use interface::TaskCreatorTrait;

--- a/src/creator/mod.rs
+++ b/src/creator/mod.rs
@@ -1,0 +1,8 @@
+pub mod base;
+pub mod implementations;
+pub mod interface;
+pub mod types;
+
+// Re-export main types and traits
+pub use implementations::{default::Creator, listening::ListeningCreator, queue::SimpleTaskQueue};
+pub use interface::TaskCreatorTrait;

--- a/src/creator/tests/base_creator_tests.rs
+++ b/src/creator/tests/base_creator_tests.rs
@@ -1,0 +1,108 @@
+use crate::creator::base::{BaseCreator, ContractProviderTrait};
+use anyhow::Result;
+
+/// Mock contract provider for testing BaseCreator
+#[derive(Debug)]
+struct MockContractProvider {
+    state: u64,
+    should_fail: bool,
+}
+
+impl MockContractProvider {
+    fn new(state: u64) -> Self {
+        Self {
+            state,
+            should_fail: false,
+        }
+    }
+
+    fn new_failing() -> Self {
+        Self {
+            state: 0,
+            should_fail: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ContractProviderTrait for MockContractProvider {
+    type State = u64;
+
+    async fn get_current_state(&self) -> Result<u64> {
+        if self.should_fail {
+            Err(anyhow::anyhow!("Mock provider failure"))
+        } else {
+            Ok(self.state)
+        }
+    }
+
+    async fn encode_state_call(&self, state: &u64) -> Vec<u8> {
+        state.to_le_bytes().to_vec()
+    }
+}
+
+#[tokio::test]
+async fn test_base_creator_new() {
+    let provider = MockContractProvider::new(42);
+    let base_creator = BaseCreator::new(provider);
+
+    // Test that the creator was created successfully
+    assert!(base_creator.get_current_state().await.is_ok());
+}
+
+#[tokio::test]
+async fn test_base_creator_get_current_state() {
+    let expected_state = 123;
+    let provider = MockContractProvider::new(expected_state);
+    let base_creator = BaseCreator::new(provider);
+
+    let result = base_creator.get_current_state().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), expected_state);
+}
+
+#[tokio::test]
+async fn test_base_creator_get_current_state_failure() {
+    let provider = MockContractProvider::new_failing();
+    let base_creator = BaseCreator::new(provider);
+
+    let result = base_creator.get_current_state().await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Mock provider failure");
+}
+
+#[tokio::test]
+async fn test_base_creator_encode_state_call() {
+    let provider = MockContractProvider::new(42);
+    let base_creator = BaseCreator::new(provider);
+    let state = 456;
+
+    let encoded = base_creator.encode_state_call(&state).await;
+    let expected = state.to_le_bytes().to_vec();
+
+    assert_eq!(encoded, expected);
+}
+
+#[tokio::test]
+async fn test_base_creator_get_task_data() {
+    let provider = MockContractProvider::new(42);
+    let base_creator = BaseCreator::new(provider);
+
+    let result = base_creator.get_task_data().await;
+    assert!(result.is_ok());
+
+    let task_data = result.unwrap();
+    assert_eq!(task_data.var1, "default_var1");
+    assert_eq!(task_data.var2, "default_var2");
+    assert_eq!(task_data.var3, "default_var3");
+}
+
+#[tokio::test]
+async fn test_base_creator_get_task_data_failure() {
+    let provider = MockContractProvider::new_failing();
+    let base_creator = BaseCreator::new(provider);
+
+    let result = base_creator.get_task_data().await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Mock provider failure");
+}

--- a/src/creator/tests/contract_provider_tests.rs
+++ b/src/creator/tests/contract_provider_tests.rs
@@ -1,0 +1,157 @@
+use crate::creator::base::ContractProviderTrait;
+use anyhow::Result;
+
+/// Mock contract provider with u64 state
+#[derive(Debug)]
+struct MockU64Provider {
+    state: u64,
+    should_fail: bool,
+}
+
+impl MockU64Provider {
+    fn new(state: u64) -> Self {
+        Self {
+            state,
+            should_fail: false,
+        }
+    }
+
+    fn new_failing() -> Self {
+        Self {
+            state: 0,
+            should_fail: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ContractProviderTrait for MockU64Provider {
+    type State = u64;
+
+    async fn get_current_state(&self) -> Result<u64> {
+        if self.should_fail {
+            Err(anyhow::anyhow!("Mock u64 provider failure"))
+        } else {
+            Ok(self.state)
+        }
+    }
+
+    async fn encode_state_call(&self, state: &u64) -> Vec<u8> {
+        state.to_le_bytes().to_vec()
+    }
+}
+
+/// Mock contract provider with String state
+#[derive(Debug)]
+struct MockStringProvider {
+    state: String,
+    should_fail: bool,
+}
+
+impl MockStringProvider {
+    fn new(state: String) -> Self {
+        Self {
+            state,
+            should_fail: false,
+        }
+    }
+
+    fn new_failing() -> Self {
+        Self {
+            state: String::new(),
+            should_fail: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ContractProviderTrait for MockStringProvider {
+    type State = String;
+
+    async fn get_current_state(&self) -> Result<String> {
+        if self.should_fail {
+            Err(anyhow::anyhow!("Mock string provider failure"))
+        } else {
+            Ok(self.state.clone())
+        }
+    }
+
+    async fn encode_state_call(&self, state: &String) -> Vec<u8> {
+        state.as_bytes().to_vec()
+    }
+}
+
+#[tokio::test]
+async fn test_u64_provider_get_current_state() {
+    let expected_state = 42;
+    let provider = MockU64Provider::new(expected_state);
+
+    let result = provider.get_current_state().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), expected_state);
+}
+
+#[tokio::test]
+async fn test_u64_provider_get_current_state_failure() {
+    let provider = MockU64Provider::new_failing();
+
+    let result = provider.get_current_state().await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Mock u64 provider failure");
+}
+
+#[tokio::test]
+async fn test_u64_provider_encode_state_call() {
+    let provider = MockU64Provider::new(0);
+    let state = 123;
+
+    let encoded = provider.encode_state_call(&state).await;
+    let expected = state.to_le_bytes().to_vec();
+
+    assert_eq!(encoded, expected);
+}
+
+#[tokio::test]
+async fn test_string_provider_get_current_state() {
+    let expected_state = "test_state".to_string();
+    let provider = MockStringProvider::new(expected_state.clone());
+
+    let result = provider.get_current_state().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), expected_state);
+}
+
+#[tokio::test]
+async fn test_string_provider_get_current_state_failure() {
+    let provider = MockStringProvider::new_failing();
+
+    let result = provider.get_current_state().await;
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Mock string provider failure"
+    );
+}
+
+#[tokio::test]
+async fn test_string_provider_encode_state_call() {
+    let provider = MockStringProvider::new(String::new());
+    let state = "test_string".to_string();
+
+    let encoded = provider.encode_state_call(&state).await;
+    let expected = state.as_bytes().to_vec();
+
+    assert_eq!(encoded, expected);
+}
+
+#[tokio::test]
+async fn test_provider_trait_object_safety() {
+    // Test that we can use trait objects (Send + Sync requirements)
+    let provider = MockU64Provider::new(42);
+    let provider_ref: &dyn ContractProviderTrait<State = u64> = &provider;
+
+    // Test that we can call methods on the trait object
+    let state = provider_ref.get_current_state().await;
+    assert!(state.is_ok());
+    assert_eq!(state.unwrap(), 42);
+}

--- a/src/creator/tests/creator_implementation_tests.rs
+++ b/src/creator/tests/creator_implementation_tests.rs
@@ -1,0 +1,239 @@
+use crate::creator::{
+    base::ContractProviderTrait,
+    implementations::{default::Creator, listening::ListeningCreator, queue::SimpleTaskQueue},
+    interface::TaskCreatorTrait,
+    types::TaskQueue,
+};
+use crate::ingress::TaskRequest;
+use anyhow::Result;
+
+/// Mock contract provider for testing creator implementations
+#[derive(Debug)]
+struct MockProvider {
+    state: u64,
+    should_fail: bool,
+}
+
+impl MockProvider {
+    fn new(state: u64) -> Self {
+        Self {
+            state,
+            should_fail: false,
+        }
+    }
+
+    fn new_failing() -> Self {
+        Self {
+            state: 0,
+            should_fail: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ContractProviderTrait for MockProvider {
+    type State = u64;
+
+    async fn get_current_state(&self) -> Result<u64> {
+        if self.should_fail {
+            Err(anyhow::anyhow!("Mock provider failure"))
+        } else {
+            Ok(self.state)
+        }
+    }
+
+    async fn encode_state_call(&self, state: &u64) -> Vec<u8> {
+        state.to_le_bytes().to_vec()
+    }
+}
+
+#[tokio::test]
+async fn test_creator_new() {
+    let provider = MockProvider::new(42);
+    let creator = Creator::new(provider);
+
+    // Test that the creator was created successfully
+    assert!(creator.get_current_state().await.is_ok());
+}
+
+#[tokio::test]
+async fn test_creator_get_current_state() {
+    let expected_state = 123;
+    let provider = MockProvider::new(expected_state);
+    let creator = Creator::new(provider);
+
+    let result = creator.get_current_state().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), expected_state);
+}
+
+#[tokio::test]
+async fn test_creator_get_current_state_failure() {
+    let provider = MockProvider::new_failing();
+    let creator = Creator::new(provider);
+
+    let result = creator.get_current_state().await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Mock provider failure");
+}
+
+#[tokio::test]
+async fn test_creator_get_payload_and_state() {
+    let expected_state = 456;
+    let provider = MockProvider::new(expected_state);
+    let creator = Creator::new(provider);
+
+    let result = creator.get_payload_and_state().await;
+    assert!(result.is_ok());
+
+    let (payload, state) = result.unwrap();
+    assert_eq!(state, expected_state);
+
+    // Verify payload contains the encoded state
+    let expected_payload = expected_state.to_le_bytes().to_vec();
+    assert!(payload.len() > expected_payload.len()); // Should contain task data + state
+}
+
+#[tokio::test]
+async fn test_creator_get_payload_and_state_failure() {
+    let provider = MockProvider::new_failing();
+    let creator = Creator::new(provider);
+
+    let result = creator.get_payload_and_state().await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("Creator error"));
+}
+
+#[tokio::test]
+async fn test_listening_creator_new() {
+    let provider = MockProvider::new(42);
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+
+    // Test that the creator was created successfully
+    assert!(creator.get_current_state().await.is_ok());
+}
+
+#[tokio::test]
+async fn test_listening_creator_get_current_state() {
+    let expected_state = 123;
+    let provider = MockProvider::new(expected_state);
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+
+    let result = creator.get_current_state().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), expected_state);
+}
+
+#[tokio::test]
+async fn test_listening_creator_get_current_state_failure() {
+    let provider = MockProvider::new_failing();
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+
+    let result = creator.get_current_state().await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Mock provider failure");
+}
+
+#[tokio::test]
+async fn test_listening_creator_get_next_task_empty_queue() {
+    let provider = MockProvider::new(42);
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+
+    // Queue should be empty initially
+    let task = creator.get_next_task().await;
+    assert!(task.is_none());
+}
+
+#[tokio::test]
+async fn test_listening_creator_get_next_task_with_task() {
+    let provider = MockProvider::new(42);
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+
+    // Add a task to the queue
+    let task_request = TaskRequest {
+        body: crate::ingress::TaskRequestBody {
+            var1: "test1".to_string(),
+            var2: "test2".to_string(),
+            var3: "test3".to_string(),
+        },
+    };
+    creator.queue.push(task_request.clone());
+
+    // Should get the task from the queue
+    let task = creator.get_next_task().await;
+    assert!(task.is_some());
+    assert_eq!(task.unwrap().body.var1, "test1");
+}
+
+#[tokio::test]
+async fn test_listening_creator_get_payload_for_state() {
+    let provider = MockProvider::new(42);
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+    let state = 789;
+
+    let result = creator.get_payload_for_state(state).await;
+    assert!(result.is_ok());
+
+    let (payload, returned_state) = result.unwrap();
+    assert_eq!(returned_state, state);
+
+    // Verify payload contains the encoded state
+    let expected_payload = state.to_le_bytes().to_vec();
+    assert!(payload.len() >= expected_payload.len());
+}
+
+#[tokio::test]
+async fn test_listening_creator_get_payload_and_state_with_task() {
+    let provider = MockProvider::new(456);
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+
+    // Add a task to the queue
+    let task_request = TaskRequest {
+        body: crate::ingress::TaskRequestBody {
+            var1: "task1".to_string(),
+            var2: "task2".to_string(),
+            var3: "task3".to_string(),
+        },
+    };
+    creator.queue.push(task_request);
+
+    // Should get payload and state successfully
+    let result = creator.get_payload_and_state().await;
+    assert!(result.is_ok());
+
+    let (payload, state) = result.unwrap();
+    assert_eq!(state, 456);
+    assert!(!payload.is_empty());
+}
+
+#[tokio::test]
+async fn test_listening_creator_get_payload_and_state_failure() {
+    let provider = MockProvider::new_failing();
+    let queue = SimpleTaskQueue::new();
+    let creator = ListeningCreator::new(provider, queue);
+
+    // Test that get_current_state fails (which is called by get_payload_and_state)
+    let result = creator.get_current_state().await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Mock provider failure");
+}
+
+#[tokio::test]
+async fn test_task_creator_trait_object_safety() {
+    // Test that we can use trait objects
+    let provider = MockProvider::new(42);
+    let creator = Creator::new(provider);
+    let creator_ref: &dyn TaskCreatorTrait<u64> = &creator;
+
+    // Test that we can call methods on the trait object
+    let state = creator_ref.get_current_state().await;
+    assert!(state.is_ok());
+    assert_eq!(state.unwrap(), 42);
+}

--- a/src/creator/tests/mod.rs
+++ b/src/creator/tests/mod.rs
@@ -1,0 +1,5 @@
+pub mod base_creator_tests;
+pub mod contract_provider_tests;
+pub mod creator_implementation_tests;
+pub mod task_queue_tests;
+pub mod types_tests;

--- a/src/creator/tests/task_queue_tests.rs
+++ b/src/creator/tests/task_queue_tests.rs
@@ -1,0 +1,240 @@
+use crate::creator::{implementations::queue::SimpleTaskQueue, types::TaskQueue};
+use crate::ingress::TaskRequest;
+
+/// Mock task queue implementation for testing
+#[derive(Debug)]
+struct MockTaskQueue {
+    tasks: Vec<TaskRequest>,
+    should_fail: bool,
+}
+
+impl MockTaskQueue {
+    fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            should_fail: false,
+        }
+    }
+
+    fn new_failing() -> Self {
+        Self {
+            tasks: Vec::new(),
+            should_fail: true,
+        }
+    }
+
+    fn with_tasks(tasks: Vec<TaskRequest>) -> Self {
+        Self {
+            tasks,
+            should_fail: false,
+        }
+    }
+}
+
+impl TaskQueue for MockTaskQueue {
+    fn push(&self, _task: TaskRequest) {
+        if !self.should_fail {
+            // In a real implementation, this would be thread-safe
+            // For testing, we'll just simulate the behavior
+        }
+    }
+
+    fn pop(&self) -> Option<TaskRequest> {
+        if self.should_fail {
+            None
+        } else {
+            self.tasks.last().cloned()
+        }
+    }
+}
+
+#[test]
+fn test_simple_task_queue_new() {
+    let queue = SimpleTaskQueue::new();
+
+    // Test that the queue was created successfully
+    assert!(queue.pop().is_none()); // Should be empty initially
+}
+
+#[test]
+fn test_simple_task_queue_default() {
+    let queue = SimpleTaskQueue::default();
+
+    // Test that the default implementation works
+    assert!(queue.pop().is_none()); // Should be empty initially
+}
+
+#[test]
+fn test_simple_task_queue_push_and_pop() {
+    let queue = SimpleTaskQueue::new();
+
+    // Create a test task
+    let task = TaskRequest {
+        body: crate::ingress::TaskRequestBody {
+            var1: "test1".to_string(),
+            var2: "test2".to_string(),
+            var3: "test3".to_string(),
+        },
+    };
+
+    // Push the task
+    queue.push(task.clone());
+
+    // Pop the task
+    let popped_task = queue.pop();
+    assert!(popped_task.is_some());
+    assert_eq!(popped_task.unwrap().body.var1, "test1");
+}
+
+#[test]
+fn test_simple_task_queue_multiple_tasks() {
+    let queue = SimpleTaskQueue::new();
+
+    // Create multiple test tasks
+    let task1 = TaskRequest {
+        body: crate::ingress::TaskRequestBody {
+            var1: "task1".to_string(),
+            var2: "task2".to_string(),
+            var3: "task3".to_string(),
+        },
+    };
+
+    let task2 = TaskRequest {
+        body: crate::ingress::TaskRequestBody {
+            var1: "task4".to_string(),
+            var2: "task5".to_string(),
+            var3: "task6".to_string(),
+        },
+    };
+
+    // Push tasks
+    queue.push(task1.clone());
+    queue.push(task2.clone());
+
+    // Pop tasks (should be in LIFO order for Vec::pop)
+    let popped_task2 = queue.pop();
+    assert!(popped_task2.is_some());
+    assert_eq!(popped_task2.unwrap().body.var1, "task4");
+
+    let popped_task1 = queue.pop();
+    assert!(popped_task1.is_some());
+    assert_eq!(popped_task1.unwrap().body.var1, "task1");
+
+    // Queue should be empty now
+    assert!(queue.pop().is_none());
+}
+
+#[test]
+fn test_simple_task_queue_empty_pop() {
+    let queue = SimpleTaskQueue::new();
+
+    // Pop from empty queue
+    let task = queue.pop();
+    assert!(task.is_none());
+}
+
+#[test]
+fn test_simple_task_queue_get_queue() {
+    let queue = SimpleTaskQueue::new();
+    let queue_arc = queue.get_queue();
+
+    // Test that we can get the underlying queue
+    assert!(queue_arc.lock().is_ok());
+}
+
+#[test]
+fn test_mock_task_queue_new() {
+    let queue = MockTaskQueue::new();
+
+    // Test that the mock queue was created successfully
+    assert!(queue.pop().is_none()); // Should be empty initially
+}
+
+#[test]
+fn test_mock_task_queue_with_tasks() {
+    let task = TaskRequest {
+        body: crate::ingress::TaskRequestBody {
+            var1: "test1".to_string(),
+            var2: "test2".to_string(),
+            var3: "test3".to_string(),
+        },
+    };
+
+    let queue = MockTaskQueue::with_tasks(vec![task.clone()]);
+
+    // Should return the task
+    let popped_task = queue.pop();
+    assert!(popped_task.is_some());
+    assert_eq!(popped_task.unwrap().body.var1, "test1");
+}
+
+#[test]
+fn test_mock_task_queue_failing() {
+    let queue = MockTaskQueue::new_failing();
+
+    // Should always return None when failing
+    assert!(queue.pop().is_none());
+}
+
+#[test]
+fn test_task_queue_trait_object_safety() {
+    // Test that we can use trait objects
+    let queue = SimpleTaskQueue::new();
+    let queue_ref: &dyn TaskQueue = &queue;
+
+    // Test that we can call methods on the trait object
+    queue_ref.push(TaskRequest {
+        body: crate::ingress::TaskRequestBody {
+            var1: "test".to_string(),
+            var2: "test".to_string(),
+            var3: "test".to_string(),
+        },
+    });
+
+    let task = queue_ref.pop();
+    assert!(task.is_some());
+    assert_eq!(task.unwrap().body.var1, "test");
+}
+
+#[test]
+fn test_task_queue_send_sync() {
+    // Test that TaskQueue implementations are Send + Sync
+    let queue = SimpleTaskQueue::new();
+
+    // This test ensures the trait bounds are satisfied
+    fn assert_send_sync<T: Send + Sync>(_t: T) {}
+    assert_send_sync(queue);
+
+    // Additional verification that the queue actually works
+    let queue2 = SimpleTaskQueue::new();
+    assert!(queue2.pop().is_none());
+}
+
+#[test]
+fn test_simple_task_queue_concurrent_access() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let queue = Arc::new(SimpleTaskQueue::new());
+    let queue_clone = queue.clone();
+
+    // Spawn a thread to push a task
+    let handle = thread::spawn(move || {
+        let task = TaskRequest {
+            body: crate::ingress::TaskRequestBody {
+                var1: "thread_task".to_string(),
+                var2: "test2".to_string(),
+                var3: "test3".to_string(),
+            },
+        };
+        queue_clone.push(task);
+    });
+
+    // Wait for the thread to complete
+    handle.join().unwrap();
+
+    // Pop the task from the main thread
+    let task = queue.pop();
+    assert!(task.is_some());
+    assert_eq!(task.unwrap().body.var1, "thread_task");
+}

--- a/src/creator/tests/types_tests.rs
+++ b/src/creator/tests/types_tests.rs
@@ -1,0 +1,214 @@
+use crate::creator::types::{TaskData, TaskQueue};
+use crate::ingress::TaskRequest;
+
+/// Mock task queue for testing TaskData
+#[derive(Debug)]
+struct MockQueue;
+
+impl TaskQueue for MockQueue {
+    fn push(&self, _task: TaskRequest) {
+        // Mock implementation
+    }
+
+    fn pop(&self) -> Option<TaskRequest> {
+        None
+    }
+}
+
+#[test]
+fn test_task_data_new() {
+    let task_data = TaskData::new(
+        "var1_value".to_string(),
+        "var2_value".to_string(),
+        "var3_value".to_string(),
+    );
+
+    assert_eq!(task_data.var1, "var1_value");
+    assert_eq!(task_data.var2, "var2_value");
+    assert_eq!(task_data.var3, "var3_value");
+}
+
+#[test]
+fn test_task_data_default() {
+    let task_data = TaskData::default();
+
+    assert_eq!(task_data.var1, "default_var1");
+    assert_eq!(task_data.var2, "default_var2");
+    assert_eq!(task_data.var3, "default_var3");
+}
+
+#[test]
+fn test_task_data_encode_into_payload() {
+    let task_data = TaskData::new(
+        "test1".to_string(),
+        "test2".to_string(),
+        "test3".to_string(),
+    );
+
+    let initial_payload = vec![1, 2, 3, 4];
+    let result = task_data.encode_into_payload(initial_payload.clone());
+
+    // Should contain the initial payload plus the encoded task data
+    assert!(result.len() > initial_payload.len());
+
+    // Should contain the task data strings with null terminators
+    let result_str = String::from_utf8_lossy(&result);
+    assert!(result_str.contains("test1"));
+    assert!(result_str.contains("test2"));
+    assert!(result_str.contains("test3"));
+}
+
+#[test]
+fn test_task_data_encode_into_payload_empty_initial() {
+    let task_data = TaskData::new("var1".to_string(), "var2".to_string(), "var3".to_string());
+
+    let result = task_data.encode_into_payload(vec![]);
+
+    // Should contain the task data even with empty initial payload
+    assert!(!result.is_empty());
+
+    let result_str = String::from_utf8_lossy(&result);
+    assert!(result_str.contains("var1"));
+    assert!(result_str.contains("var2"));
+    assert!(result_str.contains("var3"));
+}
+
+#[test]
+fn test_task_data_encode_into_payload_with_null_terminators() {
+    let task_data = TaskData::new("hello".to_string(), "world".to_string(), "test".to_string());
+
+    let result = task_data.encode_into_payload(vec![]);
+
+    // Check that null terminators are present
+    let mut null_count = 0;
+    for &byte in &result {
+        if byte == 0 {
+            null_count += 1;
+        }
+    }
+
+    // Should have 3 null terminators (one for each string)
+    assert_eq!(null_count, 3);
+}
+
+#[test]
+fn test_task_data_encode_into_payload_preserves_initial_data() {
+    let task_data = TaskData::new("var1".to_string(), "var2".to_string(), "var3".to_string());
+
+    let initial_payload = vec![1, 2, 3, 4, 5];
+    let result = task_data.encode_into_payload(initial_payload.clone());
+
+    // The initial payload should be preserved at the beginning
+    assert_eq!(
+        &result[0..initial_payload.len()],
+        initial_payload.as_slice()
+    );
+}
+
+#[test]
+fn test_task_data_with_empty_strings() {
+    let task_data = TaskData::new("".to_string(), "".to_string(), "".to_string());
+
+    let result = task_data.encode_into_payload(vec![]);
+
+    // Should still contain null terminators even for empty strings
+    let mut null_count = 0;
+    for &byte in &result {
+        if byte == 0 {
+            null_count += 1;
+        }
+    }
+
+    assert_eq!(null_count, 3);
+}
+
+#[test]
+fn test_task_data_with_unicode_strings() {
+    let task_data = TaskData::new(
+        "hello 世界".to_string(),
+        "world 🌍".to_string(),
+        "test 🧪".to_string(),
+    );
+
+    let result = task_data.encode_into_payload(vec![]);
+
+    // Should handle unicode correctly
+    let result_str = String::from_utf8_lossy(&result);
+    assert!(result_str.contains("hello 世界"));
+    assert!(result_str.contains("world 🌍"));
+    assert!(result_str.contains("test 🧪"));
+}
+
+#[test]
+fn test_task_queue_trait_bounds() {
+    // Test that TaskQueue trait bounds are satisfied
+    let queue = MockQueue;
+
+    // Test Send + Sync bounds
+    fn assert_send_sync<T: Send + Sync>(_t: T) {}
+    assert_send_sync(queue);
+
+    // Additional verification that the mock queue works as expected
+    let queue2 = MockQueue;
+    assert!(queue2.pop().is_none());
+}
+
+#[test]
+fn test_task_data_clone() {
+    let task_data = TaskData::new(
+        "original1".to_string(),
+        "original2".to_string(),
+        "original3".to_string(),
+    );
+
+    let cloned = task_data.clone();
+
+    assert_eq!(task_data.var1, cloned.var1);
+    assert_eq!(task_data.var2, cloned.var2);
+    assert_eq!(task_data.var3, cloned.var3);
+}
+
+#[test]
+fn test_task_data_debug() {
+    let task_data = TaskData::new(
+        "debug1".to_string(),
+        "debug2".to_string(),
+        "debug3".to_string(),
+    );
+
+    let debug_str = format!("{:?}", task_data);
+
+    // Should contain the field names and values
+    assert!(debug_str.contains("debug1"));
+    assert!(debug_str.contains("debug2"));
+    assert!(debug_str.contains("debug3"));
+}
+
+#[test]
+fn test_task_data_equality() {
+    let task_data1 = TaskData::new(
+        "same1".to_string(),
+        "same2".to_string(),
+        "same3".to_string(),
+    );
+
+    let task_data2 = TaskData::new(
+        "same1".to_string(),
+        "same2".to_string(),
+        "same3".to_string(),
+    );
+
+    let task_data3 = TaskData::new(
+        "different1".to_string(),
+        "same2".to_string(),
+        "same3".to_string(),
+    );
+
+    // Should be equal when all fields are the same
+    assert_eq!(task_data1.var1, task_data2.var1);
+    assert_eq!(task_data1.var2, task_data2.var2);
+    assert_eq!(task_data1.var3, task_data2.var3);
+
+    // Should be different when fields differ
+    assert_ne!(task_data1.var1, task_data3.var1);
+}

--- a/src/creator/types.rs
+++ b/src/creator/types.rs
@@ -1,0 +1,41 @@
+use crate::ingress::TaskRequest;
+
+/// Trait for task queue operations
+#[allow(dead_code)]
+pub trait TaskQueue: Send + Sync {
+    fn push(&self, task: TaskRequest);
+    fn pop(&self) -> Option<TaskRequest>;
+}
+
+/// Task data structure for payload generation
+pub struct TaskData {
+    pub var1: String,
+    pub var2: String,
+    pub var3: String,
+}
+
+impl TaskData {
+    pub fn new(var1: String, var2: String, var3: String) -> Self {
+        Self { var1, var2, var3 }
+    }
+
+    pub fn encode_into_payload(&self, mut payload: Vec<u8>) -> Vec<u8> {
+        payload.extend_from_slice(self.var1.as_bytes());
+        payload.push(0); // null terminator
+        payload.extend_from_slice(self.var2.as_bytes());
+        payload.push(0); // null terminator
+        payload.extend_from_slice(self.var3.as_bytes());
+        payload.push(0); // null terminator
+        payload
+    }
+}
+
+impl Default for TaskData {
+    fn default() -> Self {
+        Self {
+            var1: "default_var1".to_string(),
+            var2: "default_var2".to_string(),
+            var3: "default_var3".to_string(),
+        }
+    }
+}

--- a/src/creator/types.rs
+++ b/src/creator/types.rs
@@ -8,6 +8,7 @@ pub trait TaskQueue: Send + Sync {
 }
 
 /// Task data structure for payload generation
+#[derive(Debug, Clone)]
 pub struct TaskData {
     pub var1: String,
     pub var2: String,

--- a/src/handlers/counter_provider.rs
+++ b/src/handlers/counter_provider.rs
@@ -1,0 +1,34 @@
+use alloy::{primitives::U256, sol_types::SolValue};
+use anyhow::Result;
+
+use crate::bindings::{WalletProvider as AlloyProvider, counter::Counter};
+use crate::creator::base::ContractProviderTrait;
+
+/// Concrete implementation of ContractProvider for alloy-based counter contract.
+///
+/// This provider interacts with a simple counter contract that maintains
+/// a single u64 value as its state.
+pub struct CounterProvider {
+    counter: Counter::CounterInstance<(), AlloyProvider>,
+}
+
+impl CounterProvider {
+    pub fn new(counter_address: alloy::primitives::Address, provider: AlloyProvider) -> Self {
+        let counter = Counter::new(counter_address, provider);
+        Self { counter }
+    }
+}
+
+#[async_trait::async_trait]
+impl ContractProviderTrait for CounterProvider {
+    type State = u64;
+
+    async fn get_current_state(&self) -> Result<u64> {
+        let current_state = self.counter.number().call().await?;
+        Ok(current_state._0.to::<u64>())
+    }
+
+    async fn encode_state_call(&self, state: &u64) -> Vec<u8> {
+        U256::from(*state).abi_encode()
+    }
+}

--- a/src/handlers/counter_validator.rs
+++ b/src/handlers/counter_validator.rs
@@ -1,10 +1,10 @@
-use crate::{bindings::counter::Counter, wire};
+use crate::{
+    bindings::{ReadOnlyProvider, counter::Counter},
+    wire,
+};
 use alloy::sol_types::SolValue;
 use alloy_primitives::U256;
-use alloy_provider::{
-    ProviderBuilder, RootProvider,
-    fillers::{BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller},
-};
+use alloy_provider::ProviderBuilder;
 use anyhow::Result;
 use commonware_codec::{DecodeExt, ReadExt};
 use commonware_cryptography::sha256::Digest;
@@ -16,7 +16,7 @@ use crate::validator::interface::ValidatorTrait;
 
 /// Counter-specific validator implementation.
 pub struct CounterValidator {
-    counter: Counter::CounterInstance<(), CounterProvider>,
+    counter: Counter::CounterInstance<(), ReadOnlyProvider>,
 }
 
 impl CounterValidator {
@@ -72,12 +72,3 @@ impl ValidatorTrait for CounterValidator {
         Ok(payload_hash)
     }
 }
-
-/// Type alias to reduce complexity
-type CounterProvider = FillProvider<
-    JoinFill<
-        alloy_provider::Identity,
-        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-    >,
-    RootProvider,
->;

--- a/src/handlers/creator.rs
+++ b/src/handlers/creator.rs
@@ -1,60 +1,14 @@
-use crate::bindings::counter::Counter;
-use crate::handlers::{CounterProvider, TaskCreator};
-use alloy::{
-    primitives::{Address, U256},
-    sol_types::SolValue,
-};
+use crate::creator::Creator;
+use crate::handlers::counter_provider::CounterProvider;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
-use anyhow::Result;
 use commonware_eigenlayer::config::AvsDeployment;
 use std::{env, str::FromStr};
 
-pub struct Creator {
-    counter: Counter::CounterInstance<(), CounterProvider>,
-}
-
-impl Creator {
-    pub fn new(provider: CounterProvider, counter_address: Address) -> Self {
-        let counter = Counter::new(counter_address, provider.clone());
-        Self { counter }
-    }
-
-    pub async fn get_current_number(&self) -> Result<u64> {
-        let current_number = self.counter.number().call().await?;
-        Ok(current_number._0.to::<u64>())
-    }
-
-    pub async fn encode_number_call(&self, number: U256) -> Vec<u8> {
-        number.abi_encode()
-    }
-
-    async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)> {
-        let current_number = self.get_current_number().await?;
-        let encoded = self.encode_number_call(U256::from(current_number)).await;
-
-        // For non-ingress mode, encode default variables into the payload
-        let mut payload = encoded;
-        let default_vars = ["default_var1", "default_var2", "default_var3"];
-        for var in default_vars {
-            payload.extend_from_slice(var.as_bytes());
-            payload.push(0); // null terminator
-        }
-
-        Ok((payload, current_number))
-    }
-}
-
-impl TaskCreator for Creator {
-    async fn get_payload_and_round(&self) -> anyhow::Result<(Vec<u8>, u64)> {
-        self.get_payload_and_round()
-            .await
-            .map_err(|e| anyhow::anyhow!("Creator error: {}", e))
-    }
-}
+pub type DefaultCreator = Creator<CounterProvider>;
 
 // Helper function to create a new Creator instance
-pub async fn create_creator() -> anyhow::Result<Creator> {
+pub async fn create_creator() -> anyhow::Result<DefaultCreator> {
     let http_rpc = env::var("HTTP_RPC").expect("HTTP_RPC must be set");
     let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
     let signer = PrivateKeySigner::from_str(&private_key)
@@ -71,5 +25,6 @@ pub async fn create_creator() -> anyhow::Result<Creator> {
         .counter_address()
         .map_err(|e| anyhow::anyhow!("Failed to get counter address: {}", e))?;
 
-    Ok(Creator::new(provider, counter_address))
+    let contract_provider = CounterProvider::new(counter_address, provider.clone());
+    Ok(Creator::new(contract_provider))
 }

--- a/src/handlers/executor.rs
+++ b/src/handlers/executor.rs
@@ -4,7 +4,7 @@ use crate::bindings::blssigcheckoperatorstateretriever::BLSSigCheckOperatorState
 };
 use crate::bindings::blssigcheckoperatorstateretriever::BN254::G1Point;
 use crate::bindings::counter::{self, Counter};
-use crate::handlers::{CounterProvider, ViewOnlyProvider};
+use crate::bindings::{ReadOnlyProvider, WalletProvider};
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::sol_types::SolValue;
 use alloy_primitives::{Address, Bytes, FixedBytes, U256};
@@ -17,10 +17,10 @@ use eigen_crypto_bls::convert_to_g1_point;
 use std::{collections::HashMap, env, str::FromStr};
 
 pub struct Executor {
-    view_only_provider: ViewOnlyProvider,
-    bls_apk_registry: BLSApkRegistryInstance<(), ViewOnlyProvider>,
-    bls_operator_state_retriever: BLSSigCheckOperatorStateRetrieverInstance<(), ViewOnlyProvider>,
-    counter: Counter::CounterInstance<(), CounterProvider>,
+    view_only_provider: ReadOnlyProvider,
+    bls_apk_registry: BLSApkRegistryInstance<(), ReadOnlyProvider>,
+    bls_operator_state_retriever: BLSSigCheckOperatorStateRetrieverInstance<(), ReadOnlyProvider>,
+    counter: Counter::CounterInstance<(), WalletProvider>,
     registry_coordinator_address: Address,
     g1_hash_map: HashMap<PublicKey, Address>,
 }

--- a/src/handlers/listening_creator.rs
+++ b/src/handlers/listening_creator.rs
@@ -1,98 +1,13 @@
-use alloy::{
-    primitives::{Address, U256},
-    sol_types::SolValue,
-};
+use crate::creator::{ListeningCreator as ListeningCreatorImpl, SimpleTaskQueue};
+use crate::handlers::counter_provider::CounterProvider;
+use crate::ingress::start_http_server;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use std::{env, str::FromStr, sync::Arc};
-use tokio::sync::Mutex;
-use tracing::info;
 
-use crate::bindings::counter::Counter;
-use crate::handlers::{CounterProvider, TaskCreator};
-use crate::ingress::{TaskRequest, start_http_server};
 use commonware_eigenlayer::config::AvsDeployment;
 
-pub struct ListeningCreator {
-    counter: Counter::CounterInstance<(), CounterProvider>,
-    queue: Arc<Mutex<Vec<TaskRequest>>>,
-}
-
-impl ListeningCreator {
-    pub fn new(provider: CounterProvider, counter_address: Address) -> Self {
-        let counter = Counter::new(counter_address, provider.clone());
-        Self {
-            counter,
-            queue: Arc::new(Mutex::new(Vec::new())),
-        }
-    }
-
-    pub async fn get_current_number(&self) -> anyhow::Result<u64> {
-        let current_number = self.counter.number().call().await?;
-        Ok(current_number._0.to::<u64>())
-    }
-
-    pub async fn encode_number_call(&self, number: U256) -> Vec<u8> {
-        number.abi_encode()
-    }
-
-    // Pulls the next task from the queue, or returns None if empty
-    pub async fn get_next_task(&self) -> Option<TaskRequest> {
-        let mut queue = self.queue.lock().await;
-        if !queue.is_empty() {
-            Some(queue.remove(0))
-        } else {
-            None
-        }
-    }
-
-    // Single entry point that can be called by the orchestrator
-    // This is where queue requests would be pulled from
-    pub async fn get_payload_and_round(&self) -> anyhow::Result<(Vec<u8>, u64)> {
-        // Wait for a task to be available
-        let task = loop {
-            if let Some(task) = self.get_next_task().await {
-                break task;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        };
-        let current_number = self.get_current_number().await?;
-        let mut payload = self.get_payload_for_round(current_number).await?.0;
-
-        // Encode the three variables into the payload
-        payload.extend_from_slice(task.body.var1.as_bytes());
-        payload.push(0); // null terminator
-        payload.extend_from_slice(task.body.var2.as_bytes());
-        payload.push(0); // null terminator
-        payload.extend_from_slice(task.body.var3.as_bytes());
-        payload.push(0); // null terminator
-
-        Ok((payload, current_number))
-    }
-
-    // Optional: Method to get payload for a specific round number
-    pub async fn get_payload_for_round(&self, round_number: u64) -> anyhow::Result<(Vec<u8>, u64)> {
-        let encoded = self.encode_number_call(U256::from(round_number)).await;
-        info!("Created payload for specific round: {}", round_number);
-        Ok((encoded, round_number))
-    }
-
-    // Start the HTTP server in a background task
-    pub async fn start_http_server(self: Arc<Self>, addr: String) {
-        let queue = self.queue.clone();
-        tokio::spawn(async move {
-            start_http_server(queue, &addr).await;
-        });
-    }
-}
-
-impl TaskCreator for ListeningCreator {
-    async fn get_payload_and_round(&self) -> anyhow::Result<(Vec<u8>, u64)> {
-        self.get_payload_and_round()
-            .await
-            .map_err(|e| anyhow::anyhow!("ListeningCreator error: {}", e))
-    }
-}
+pub type ListeningCreator = ListeningCreatorImpl<CounterProvider, SimpleTaskQueue>;
 
 // Helper function to create a new ListeningCreator instance and start HTTP server
 pub async fn create_listening_creator_with_server(
@@ -110,10 +25,13 @@ pub async fn create_listening_creator_with_server(
     let counter_address = deployment
         .counter_address()
         .map_err(|e| anyhow::anyhow!("Failed to get counter address: {}", e))?;
-    let creator = Arc::new(ListeningCreator::new(provider, counter_address));
+    let contract_provider = CounterProvider::new(counter_address, provider.clone());
+    let queue = SimpleTaskQueue::new();
+    let creator = Arc::new(ListeningCreatorImpl::new(contract_provider, queue));
     let server_creator = creator.clone();
+    let queue = server_creator.queue.get_queue();
     tokio::spawn(async move {
-        server_creator.start_http_server(addr).await;
+        start_http_server(queue, &addr).await;
     });
     Ok(creator)
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod counter_provider;
 pub mod counter_validator;
 pub mod creator;
 pub mod executor;
@@ -5,60 +6,3 @@ pub mod listening_creator;
 pub mod orchestrator;
 
 pub use orchestrator::Orchestrator;
-
-use crate::handlers::{creator::Creator, listening_creator::ListeningCreator};
-use std::sync::Arc;
-
-use alloy::{network::EthereumWallet, providers::fillers::FillProvider};
-use alloy_provider::{
-    RootProvider,
-    fillers::{BlobGasFiller, ChainIdFiller, GasFiller, JoinFill, NonceFiller, WalletFiller},
-};
-
-// Type alias for the complex provider type used across handlers
-pub type CounterProvider = FillProvider<
-    JoinFill<
-        JoinFill<
-            alloy_provider::Identity,
-            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-        >,
-        WalletFiller<EthereumWallet>,
-    >,
-    RootProvider,
->;
-
-// Type alias for view-only provider (without wallet)
-pub type ViewOnlyProvider = FillProvider<
-    JoinFill<
-        alloy_provider::Identity,
-        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-    >,
-    RootProvider,
->;
-
-/// Shared trait for creators that can generate payloads and round numbers
-pub trait TaskCreator: Send + Sync {
-    /// Get the current payload and round number
-    fn get_payload_and_round(
-        &self,
-    ) -> impl std::future::Future<Output = anyhow::Result<(Vec<u8>, u64)>> + Send;
-}
-enum TaskCreatorEnum {
-    Creator(Creator),
-    ListeningCreator(Arc<ListeningCreator>),
-}
-
-impl TaskCreator for TaskCreatorEnum {
-    async fn get_payload_and_round(&self) -> anyhow::Result<(Vec<u8>, u64)> {
-        match self {
-            TaskCreatorEnum::Creator(creator) => creator
-                .get_payload_and_round()
-                .await
-                .map_err(|e| anyhow::anyhow!("Creator error: {}", e)),
-            TaskCreatorEnum::ListeningCreator(listening_creator) => listening_creator
-                .get_payload_and_round()
-                .await
-                .map_err(|e| anyhow::anyhow!("ListeningCreator error: {}", e)),
-        }
-    }
-}

--- a/src/handlers/orchestrator.rs
+++ b/src/handlers/orchestrator.rs
@@ -1,10 +1,11 @@
+use crate::creator::TaskCreatorTrait;
 use crate::handlers::counter_validator::CounterValidator;
 use crate::handlers::creator::create_creator;
 use crate::handlers::executor::create_executor;
 use crate::handlers::listening_creator::create_listening_creator_with_server;
-use crate::handlers::{TaskCreator, TaskCreatorEnum};
 use crate::validator::Validator;
 use crate::wire::{self, aggregation::Payload};
+use std::sync::Arc;
 
 use bn254::{Bn254, G1PublicKey, PublicKey, Signature as Bn254Signature};
 use bytes::Bytes;
@@ -67,38 +68,34 @@ impl<E: Clock> Orchestrator<E> {
     ) {
         let mut hasher = Sha256::new();
         let mut signatures = HashMap::new();
-        let task_creator: TaskCreatorEnum;
         // Check if INGRESS flag is set to determine which creator to use
         let use_ingress = std::env::var("INGRESS").unwrap_or_default().to_lowercase() == "true";
-        if use_ingress {
+        let task_creator: Arc<dyn TaskCreatorTrait> = if use_ingress {
             info!("Using ListeningCreator with HTTP server on port 8080");
-            let listening_creator =
-                create_listening_creator_with_server("0.0.0.0:8080".to_string())
-                    .await
-                    .unwrap();
-            task_creator = TaskCreatorEnum::ListeningCreator(listening_creator);
+            create_listening_creator_with_server("0.0.0.0:8080".to_string())
+                .await
+                .unwrap()
         } else {
             info!("Using Creator without ingress");
-            let creator = create_creator().await.unwrap();
-            task_creator = TaskCreatorEnum::Creator(creator);
+            Arc::new(create_creator().await.unwrap())
         };
         let mut executor = create_executor().await.unwrap();
         let counter_validator = CounterValidator::new().await.unwrap();
         let validator = Validator::new(counter_validator);
 
         loop {
-            let (payload, current_number) = task_creator.get_payload_and_round().await.unwrap();
+            let (payload, current_state) = task_creator.get_payload_and_state().await.unwrap();
             hasher.update(&payload);
             let payload = hasher.finalize();
             info!(
-                round = current_number.to_string(),
+                state = current_state.to_string(),
                 msg = hex(&payload),
-                "generated payload for round"
+                "generated payload for state"
             );
 
             // Broadcast payload
             let message = wire::Aggregation {
-                round: current_number,
+                round: current_state,
                 var1: DEFAULT_VAR_1.to_string(),
                 var2: DEFAULT_VAR_2.to_string(),
                 var3: DEFAULT_VAR_3.to_string(),
@@ -110,10 +107,10 @@ impl<E: Clock> Orchestrator<E> {
                 .send(commonware_p2p::Recipients::All, Bytes::from(buf), true)
                 .await
                 .expect("failed to broadcast message");
-            signatures.insert(current_number, HashMap::new());
+            signatures.insert(current_state, HashMap::new());
             info!(
-                "Created signatures entry for round: {}, threshold is: {}",
-                current_number, self.t
+                "Created signatures entry for state: {}, threshold is: {}",
+                current_state, self.t
             );
 
             // Listen for messages until the next broadcast

--- a/src/ingress/http_server.rs
+++ b/src/ingress/http_server.rs
@@ -1,6 +1,5 @@
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
-use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tracing::info;
 
 use crate::ingress::types::{TaskRequest, TaskResponse};
@@ -21,8 +20,9 @@ pub async fn trigger_task_handler(
     // }
     // Add to queue
     {
-        let mut queue = state.lock().await;
-        queue.push(req.clone());
+        if let Ok(mut queue) = state.lock() {
+            queue.push(req.clone());
+        }
     }
     (
         StatusCode::OK,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bindings;
+pub mod creator;
 pub mod handlers;
 pub mod ingress;
 pub mod validator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod bindings;
+mod creator;
 mod handlers;
 mod ingress;
 mod validator;


### PR DESCRIPTION
Based off the architecture defined in https://github.com/BreadchainCoop/commonware-avs-router/issues/59

A few things of note:
1. No factory methods were added since it wasn't really needed at the moment and it would have been inconsistent with the newly refactored validator module.
2. Moved type aliases for the Ethereum providers into the bindings module. Can reorganize a bit if we think that's weird. Maybe "/eth/types.rs" and "/eth/bindings/*.rs"?
3. `scripts/Cargo.lock` required updating because it was using an older version of `commonware-cryptography`
4. Extended the timeout for `verify_increments.rs` script because it was timing out on my machine.