### PR TITLE
Add test and coverage steps to CI pipeline

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -41,4 +41,73 @@ jobs:
       - name: cargo check (all targets)
         run: cargo check --all-targets --all-features
 
+  test:
+    name: Test (${{ matrix.crate_dir }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate_dir: [".", "commonware-avs-node"]
+    defaults:
+      run:
+        working-directory: ${{ matrix.crate_dir }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            commonware-avs-node
+
+      - name: Run tests
+        run: cargo test --all-features --verbose
+
+  coverage:
+    name: Code Coverage (${{ matrix.crate_dir }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate_dir: [".", "commonware-avs-node"]
+    defaults:
+      run:
+        working-directory: ${{ matrix.crate_dir }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            commonware-avs-node
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ${{ matrix.crate_dir }}/lcov.info
+          flags: ${{ matrix.crate_dir == '.' && 'root' || 'avs-node' }}
+          name: ${{ matrix.crate_dir }}
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 


### PR DESCRIPTION
## Summary
- Added dedicated test job to run all tests with verbose output
- Integrated code coverage generation using cargo-llvm-cov
- Configured automatic coverage reporting to Codecov for PR visibility

## Test plan
- [x] CI workflow YAML syntax validated
- [ ] Test job runs successfully on push/PR
- [ ] Coverage reports generated and uploaded to Codecov
- [ ] Coverage results visible in PR checks

Closes #62

Note: This reopens the changes from PR #70 which was accidentally merged and then reverted.

🤖 Generated with [Claude Code](https://claude.ai/code)