### PR TITLE
Include "scripts" dir in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,13 @@ RUN mkdir src && echo 'fn main(){}' > src/main.rs
 RUN cargo build --release || true
 RUN rm -rf src
 
-# Now copy real source and do the actual build
+# Now copy real source
 COPY src ./src
+
+# Copy scripts
+COPY scripts ./scripts
+
+# Do the actual build
 RUN cargo build --release
 
 # Runtime stage


### PR DESCRIPTION
This should fix the issue with the Docker CI build pipeline.

CI run: https://github.com/BreadchainCoop/commonware-avs-router/actions/runs/17440126175/job/49520659529
Ignore the error in the manifest step. It fails because it's creating a tag from this branch name which includes a "/" which is an invalid character. This won't be the case for the "dev" "main" or "staging" branches.