### PR TITLE
feat: Add Helm Charts for Kubernetes Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,95 @@ Optional environment variables:
 
 Contract addresses are automatically loaded from the deployment JSON file.
 
+### Deployment Options
+
+### Kubernetes with Helm
+
+Deploy the router to Kubernetes using Helm charts:
+
+#### Prerequisites
+- Kubernetes cluster (1.19+)
+- Helm 3.x installed
+- kubectl configured with cluster access
+
+#### Installation
+
+1. **Basic installation with default values:**
+```bash
+helm install my-router charts/commonware-avs-router
+```
+
+2. **Installation with custom values:**
+```bash
+# Create custom values file
+cat > custom-values.yaml <<EOF
+replicaCount: 3
+image:
+  tag: "v1.0.0"
+env:
+  - name: HTTP_RPC
+    value: "https://ethereum-rpc.example.com"
+  - name: WS_RPC
+    value: "wss://ethereum-ws.example.com"
+  - name: AGGREGATION_FREQUENCY
+    value: "10"
+secrets:
+  private-key: "your-private-key-here"
+EOF
+
+# Install with custom values
+helm install my-router charts/commonware-avs-router -f custom-values.yaml
+```
+
+3. **Enable ingress:**
+```bash
+helm install my-router charts/commonware-avs-router \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.hosts[0].host=router.example.com \
+  --set ingress.hosts[0].paths[0].path=/ \
+  --set ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+#### Upgrade
+
+```bash
+# Upgrade with new values
+helm upgrade my-router charts/commonware-avs-router -f custom-values.yaml
+
+# Rollback if needed
+helm rollback my-router
+```
+
+#### Uninstallation
+
+```bash
+helm uninstall my-router
+```
+
+#### Configuration
+
+Key Helm values you can configure:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | Image repository | `ghcr.io/breadchaincoop/commonware-avs-router` |
+| `image.tag` | Image tag | `latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `service.type` | Service type | `ClusterIP` |
+| `service.port` | Service port | `8080` |
+| `ingress.enabled` | Enable ingress | `false` |
+| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `512Mi` |
+| `env` | Environment variables | `[]` |
+| `secrets` | Sensitive data | `{}` |
+| `autoscaling.enabled` | Enable HPA | `false` |
+| `autoscaling.minReplicas` | Min replicas for HPA | `1` |
+| `autoscaling.maxReplicas` | Max replicas for HPA | `10` |
+
+See `charts/commonware-avs-router/values.yaml` for complete configuration options.
+
 ### Docker
 
 Pull the latest image:

--- a/charts/commonware-avs-router/Chart.yaml
+++ b/charts/commonware-avs-router/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: commonware-avs-router
+description: A Helm chart for deploying Commonware AVS Router to Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - commonware
+  - avs
+  - router
+  - blockchain
+home: https://github.com/BreadchainCoop/commonware-avs-router-3
+sources:
+  - https://github.com/BreadchainCoop/commonware-avs-router-3
+maintainers:
+  - name: BreadchainCoop
+    url: https://github.com/BreadchainCoop

--- a/charts/commonware-avs-router/templates/_helpers.tpl
+++ b/charts/commonware-avs-router/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "commonware-avs-router.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "commonware-avs-router.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "commonware-avs-router.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "commonware-avs-router.labels" -}}
+helm.sh/chart: {{ include "commonware-avs-router.chart" . }}
+{{ include "commonware-avs-router.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "commonware-avs-router.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "commonware-avs-router.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "commonware-avs-router.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "commonware-avs-router.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/commonware-avs-router/templates/configmap.yaml
+++ b/charts/commonware-avs-router/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.configMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "commonware-avs-router.fullname" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.configMap | nindent 2 }}
+{{- end }}

--- a/charts/commonware-avs-router/templates/deployment.yaml
+++ b/charts/commonware-avs-router/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "commonware-avs-router.fullname" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "commonware-avs-router.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "commonware-avs-router.selectorLabels" . | nindent 8 }}
+        {{- with .Values.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "commonware-avs-router.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.env .Values.secrets }}
+          env:
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            {{- range $key, $value := .Values.secrets }}
+            - name: {{ $key | upper | replace "-" "_" }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "commonware-avs-router.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if or .Values.volumeMounts .Values.configMap }}
+          volumeMounts:
+            {{- if .Values.configMap }}
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+            {{- end }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.volumes .Values.configMap }}
+      volumes:
+        {{- if .Values.configMap }}
+        - name: config
+          configMap:
+            name: {{ include "commonware-avs-router.fullname" . }}
+        {{- end }}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/commonware-avs-router/templates/hpa.yaml
+++ b/charts/commonware-avs-router/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "commonware-avs-router.fullname" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "commonware-avs-router.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/commonware-avs-router/templates/ingress.yaml
+++ b/charts/commonware-avs-router/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "commonware-avs-router.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/commonware-avs-router/templates/networkpolicy.yaml
+++ b/charts/commonware-avs-router/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "commonware-avs-router.fullname" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "commonware-avs-router.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/commonware-avs-router/templates/poddisruptionbudget.yaml
+++ b/charts/commonware-avs-router/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "commonware-avs-router.fullname" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "commonware-avs-router.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/commonware-avs-router/templates/secrets.yaml
+++ b/charts/commonware-avs-router/templates/secrets.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "commonware-avs-router.fullname" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/commonware-avs-router/templates/service.yaml
+++ b/charts/commonware-avs-router/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "commonware-avs-router.fullname" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "commonware-avs-router.selectorLabels" . | nindent 4 }}

--- a/charts/commonware-avs-router/templates/serviceaccount.yaml
+++ b/charts/commonware-avs-router/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "commonware-avs-router.serviceAccountName" . }}
+  labels:
+    {{- include "commonware-avs-router.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/commonware-avs-router/values.yaml
+++ b/charts/commonware-avs-router/values.yaml
@@ -1,0 +1,176 @@
+# Default values for commonware-avs-router.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Number of replicas to deploy
+replicaCount: 1
+
+# Image configuration
+image:
+  repository: ghcr.io/breadchaincoop/commonware-avs-router
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion
+  tag: "latest"
+
+# Image pull secrets for private registry
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Service account configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Deployment annotations
+podAnnotations: {}
+
+# Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+# Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: 8080
+  annotations: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Resource limits and requests
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+# Autoscaling configuration
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+# Node selector for pod assignment
+nodeSelector: {}
+
+# Tolerations for pod assignment
+tolerations: []
+
+# Affinity rules for pod assignment
+affinity: {}
+
+# Environment variables
+env:
+  # Add your environment variables here
+  # Example:
+  # - name: LOG_LEVEL
+  #   value: "info"
+  # - name: API_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: api-secrets
+  #       key: api-key
+
+# ConfigMap data
+configMap:
+  # Add configuration files or data here
+  # Example:
+  # config.yaml: |
+  #   server:
+  #     port: 8080
+  #     host: 0.0.0.0
+
+# Secret data (base64 encoded in actual deployment)
+secrets:
+  # Add sensitive data here
+  # Example:
+  # api-key: "your-api-key"
+  # db-password: "your-password"
+
+# Health check probes
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+  successThreshold: 1
+
+# Volume mounts
+volumeMounts: []
+  # - name: config
+  #   mountPath: /etc/config
+  #   readOnly: true
+
+# Volumes
+volumes: []
+  # - name: config
+  #   configMap:
+  #     name: commonware-avs-router-config
+
+# Additional labels
+labels: {}
+
+# Pod disruption budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# Network policy
+networkPolicy:
+  enabled: false
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []


### PR DESCRIPTION
## Summary
- Implements comprehensive Helm charts for deploying commonware-avs-router to Kubernetes clusters
- Adds production-ready templates with security best practices
- Includes detailed documentation for installation and configuration

## Changes
- Created complete Helm chart structure in `charts/commonware-avs-router/`
- Added all required Kubernetes resource templates (deployment, service, ingress, configmap, secrets, etc.)
- Implemented security features (non-root user, read-only filesystem, network policies)
- Added support for autoscaling, pod disruption budgets, and high availability
- Updated README with comprehensive Helm deployment instructions

## Testing
- Validated chart with `helm lint` - passed without errors
- Tested template rendering with `helm template` - all resources render correctly
- Chart follows Helm best practices and Kubernetes security guidelines

## Closes
Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)