### PR TITLE
Add BLS key check to local testing workflow

### DIFF
--- a/.github/workflows/local-test.yml
+++ b/.github/workflows/local-test.yml
@@ -2,7 +2,7 @@ name: Integration Test
 
 on:
   push:
-    branches: [ dev, test-ci ]
+    branches: [ dev, test-ci, test-before-deprecation ]
   pull_request:
     branches: [ dev, test-ci ]
 
@@ -188,6 +188,46 @@ jobs:
 
           echo "Deployment file created successfully"
           cat .nodes/avs_deploy.json
+
+      - name: Verify BLS key files
+        run: |
+          cd eigenlayer-bls-local
+          echo "=== Checking BLS private key files ==="
+
+          for i in 1 2 3; do
+            keyfile=".nodes/operator_keys/testacc${i}.private.bls.key.json"
+
+            if [ ! -f "$keyfile" ]; then
+              echo "ERROR: Key file not found: $keyfile"
+              exit 1
+            fi
+
+            echo "Key file $i: $keyfile"
+            cat "$keyfile"
+
+            # Extract the privateKey value and check its length
+            privkey=$(cat "$keyfile" | jq -r '.privateKey')
+            keylen=${#privkey}
+
+            echo "  Private key length: $keylen characters"
+
+            # BLS keys on BN254 curve should be ~77 digits
+            if [ $keylen -lt 70 ]; then
+              echo "  ❌ ERROR: Key is too short! Expected ~77 digits, got $keylen"
+              echo "  This will cause nodes to crash immediately"
+              echo ""
+              echo "Full key contents:"
+              cat "$keyfile"
+              echo ""
+              exit 1
+            else
+              echo "  ✓ Key length looks valid ($keylen digits)"
+            fi
+
+            echo ""
+          done
+
+          echo "✓ All BLS keys are valid"
 
       - name: Start contributors
         run: |


### PR DESCRIPTION
## Background
The integration tests have been updated to include a check for valid BLS keys. This change ensures that the local testing workflow also performs this validation.

## Changes
- Modified `.github/workflows/local-test.yml`:
  - Added a new job step titled "Verify BLS key files".
  - This step iterates through `testacc1.private.bls.key.json`, `testacc2.private.bls.key.json`, and `testacc3.private.bls.key.json` in the `.nodes/operator_keys/` directory.
  - It checks for the existence of each file.
  - It uses `jq` to extract the `privateKey` value and verifies its length. A length less than 70 characters is considered an error, as BLS keys on the BN254 curve are expected to be around 77 digits.
  - The workflow will exit with an error code if any key file is missing or if a private key is too short.
  - The workflow trigger has been updated to include the `test-before-deprecation` branch.

## Testing
- [ ] Ensure the local testing workflow runs successfully with the new BLS key verification step.
- [ ] Manually inspect the output to confirm correct key file detection and length validation.
