### PR TITLE
Make quorum number configurable

### DIFF
--- a/example.env
+++ b/example.env
@@ -85,3 +85,9 @@ INGRESS=false
 # Aggregation frequency in seconds (supports fractional values)
 # Examples: 30 (default), 1, 0.5, 0.3, 0.1
 # AGGREGATION_FREQUENCY=30
+
+# =============================================================================
+# Quorum Configuration
+# =============================================================================
+# Quorum number to use (default: 0)
+# QUORUM_NUMBER=0

--- a/usecases/counter/node/src/app.rs
+++ b/usecases/counter/node/src/app.rs
@@ -152,13 +152,35 @@ pub fn main() {
         let mut recipients: Vec<(PublicKey, SocketAddr)> = Vec::new();
         // Scoped to avoid configuring two loggers
         let orchestrator_pub_key;
+        let quorum_infos;
+        let quorum_number: usize;
         {
             eigen_logging::init_logger(LogLevel::Debug);
-            let quorum_infos = get_operator_states()
+            quorum_infos = get_operator_states()
                 .await
                 .expect("Failed to get operator states");
+
+            // Parse quorum number from environment, defaulting to 0
+            quorum_number = std::env::var("QUORUM_NUMBER")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+
+            if quorum_number >= quorum_infos.len() {
+                panic!(
+                    "QUORUM_NUMBER {} is out of range (available quorums: 0..{})",
+                    quorum_number,
+                    quorum_infos.len()
+                );
+            }
+            tracing::info!(
+                quorum_number,
+                total_quorums = quorum_infos.len(),
+                "using quorum"
+            );
+
             // Configure allowed peers
-            let participants = quorum_infos[0].operators.clone(); //TODO: Fix hardcoded quorum_number
+            let participants = quorum_infos[quorum_number].operators.clone();
             if participants.is_empty() {
                 panic!("Please provide at least one participant");
             }
@@ -236,10 +258,7 @@ pub fn main() {
         // Parse contributors from operator states
         let mut contributors = Vec::new();
         let mut contributors_map = HashMap::new();
-        let quorum_infos = get_operator_states()
-            .await
-            .expect("Failed to get operator states");
-        let operators = &quorum_infos[0].operators;
+        let operators = &quorum_infos[quorum_number].operators;
         if operators.is_empty() {
             panic!("Please provide at least one contributor");
         }

--- a/usecases/counter/router/src/app.rs
+++ b/usecases/counter/router/src/app.rs
@@ -124,14 +124,35 @@ pub fn main() {
         let (mut network, mut oracle) = Network::new(context.with_label("network"), p2p_cfg);
         let mut recipients: Vec<(PublicKey, SocketAddr)>;
         let quorum_infos;
+        let quorum_number: usize;
         {
             eigen_logging::init_logger(LogLevel::Debug);
             // Get operator states and configure allowed peers
             quorum_infos = get_operator_states()
                 .await
                 .expect("Failed to get operator states");
+
+            // Parse quorum number from environment, defaulting to 0
+            quorum_number = std::env::var("QUORUM_NUMBER")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+
+            if quorum_number >= quorum_infos.len() {
+                panic!(
+                    "QUORUM_NUMBER {} is out of range (available quorums: 0..{})",
+                    quorum_number,
+                    quorum_infos.len()
+                );
+            }
+            tracing::info!(
+                quorum_number,
+                total_quorums = quorum_infos.len(),
+                "using quorum"
+            );
+
             recipients = Vec::new();
-            let participants = quorum_infos[0].operators.clone(); //TODO: Fix hardcoded quorum_number
+            let participants = quorum_infos[quorum_number].operators.clone();
             if participants.is_empty() {
                 panic!("Please provide at least one participant");
             }
@@ -181,7 +202,7 @@ pub fn main() {
         // Parse contributors from operator states
         let mut contributors = Vec::new();
         let mut contributors_map = HashMap::new();
-        let operators = &quorum_infos[0].operators;
+        let operators = &quorum_infos[quorum_number].operators;
         if operators.is_empty() {
             panic!("Please provide at least one contributor");
         }


### PR DESCRIPTION
## Summary
- Added QUORUM_NUMBER environment variable to enable multi-quorum deployments
- Defaults to quorum 0 if not specified
- Includes validation with helpful error messages for invalid quorum numbers
- Logs selected quorum and total available quorums on startup

## Changes
- Updated router and node apps to parse QUORUM_NUMBER env var
- Removed duplicate quorum state fetching in node app
- Added to example.env with documentation