### PR TITLE
fix: update bitnami/kubectl image tag to 'latest'

### DIFF
--- a/.github/workflows/k8s-integration-test.yml
+++ b/.github/workflows/k8s-integration-test.yml
@@ -48,13 +48,13 @@ jobs:
           docker pull ghcr.io/breadchaincoop/ethereum:dev
           docker pull ghcr.io/breadchaincoop/eigenlayer:dev
           docker pull ghcr.io/layr-labs/cerberus:0.0.2
-          docker pull bitnami/kubectl:1.28
+          docker pull bitnami/kubectl:latest
           docker pull busybox:1.36
 
           kind load docker-image ghcr.io/breadchaincoop/ethereum:dev --name avs-test
           kind load docker-image ghcr.io/breadchaincoop/eigenlayer:dev --name avs-test
           kind load docker-image ghcr.io/layr-labs/cerberus:0.0.2 --name avs-test
-          kind load docker-image bitnami/kubectl:1.28 --name avs-test
+          kind load docker-image bitnami/kubectl:latest --name avs-test
           kind load docker-image busybox:1.36 --name avs-test
 
       - name: Apply K8s manifests

--- a/k8s/base/nodes/statefulset.yaml
+++ b/k8s/base/nodes/statefulset.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-eigenlayer
-          image: bitnami/kubectl:1.28
+          image: bitnami/kubectl:latest
           command:
             - sh
             - -c

--- a/k8s/base/signer/deployment.yaml
+++ b/k8s/base/signer/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-eigenlayer
-          image: bitnami/kubectl:1.28
+          image: bitnami/kubectl:latest
           command:
             - sh
             - -c


### PR DESCRIPTION
## Summary

- Update bitnami/kubectl image from `1.28` to `latest` tag
- The `1.28` tag no longer exists on Docker Hub, causing CI to fail with "manifest unknown"

This fixes the CI failure in PR #139.

## Test plan

- [ ] Verify K8s Integration Test workflow passes