### PR TITLE
fix: read operator state retriever address from avs_deploy.json

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,14 +36,14 @@ jobs:
           sed -i '/^# WS_RPC=ws:\/\/localhost:8545/s/^# //' .env
           sed -i '/^# RPC_URL=http:\/\/ethereum:8545/s/^# //' .env
 
-          # Set FORK_URL for local forking from repository secret or default to Holesky
+          # Set FORK_URL for local forking from repository secret or default to Sepolia
           if [ -n "${{ secrets.RPC_URL }}" ]; then
             sed -i "s|^# FORK_URL=.*|FORK_URL=${{ secrets.RPC_URL }}|" .env
           else
-            sed -i 's|^# FORK_URL=.*|FORK_URL=https://ethereum-holesky.publicnode.com|' .env
+            sed -i 's|^# FORK_URL=.*|FORK_URL=https://ethereum-sepolia-rpc.publicnode.com|' .env
           fi
 
-          # Uncomment Holesky testnet contract addresses (needed for LOCAL mode with fork)
+          # Uncomment Sepolia testnet contract addresses (needed for LOCAL mode with fork)
           sed -i 's/^#DELEGATION_MANAGER_ADDRESS=/DELEGATION_MANAGER_ADDRESS=/' .env
           sed -i 's/^#STRATEGY_MANAGER_ADDRESS=/STRATEGY_MANAGER_ADDRESS=/' .env
           sed -i 's/^#LST_CONTRACT_ADDRESS=/LST_CONTRACT_ADDRESS=/' .env

--- a/.github/workflows/local-integration-test.yml
+++ b/.github/workflows/local-integration-test.yml
@@ -39,14 +39,14 @@ jobs:
           sed -i '/^# WS_RPC=ws:\/\/localhost:8545/s/^# //' .env
           sed -i '/^# RPC_URL=http:\/\/ethereum:8545/s/^# //' .env
 
-          # Set FORK_URL for local forking from repository secret or default to Holesky
+          # Set FORK_URL for local forking from repository secret or default to Sepolia
           if [ -n "${{ secrets.RPC_URL }}" ]; then
             sed -i "s|^# FORK_URL=.*|FORK_URL=${{ secrets.RPC_URL }}|" .env
           else
-            sed -i 's|^# FORK_URL=.*|FORK_URL=https://ethereum-holesky.publicnode.com|' .env
+            sed -i 's|^# FORK_URL=.*|FORK_URL=https://ethereum-sepolia-rpc.publicnode.com|' .env
           fi
 
-          # Uncomment Holesky testnet contract addresses (needed for LOCAL mode with fork)
+          # Uncomment Sepolia testnet contract addresses (needed for LOCAL mode with fork)
           sed -i 's/^#DELEGATION_MANAGER_ADDRESS=/DELEGATION_MANAGER_ADDRESS=/' .env
           sed -i 's/^#STRATEGY_MANAGER_ADDRESS=/STRATEGY_MANAGER_ADDRESS=/' .env
           sed -i 's/^#LST_CONTRACT_ADDRESS=/LST_CONTRACT_ADDRESS=/' .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,7 @@ services:
 
   eigenlayer:
     platform: linux/amd64
-    # Using Sepolia-compatible image from PR #24
-    image: ghcr.io/breadchaincoop/eigenlayer:pr-RonTuretzky-sepolia-support-9fa6816
+    image: ghcr.io/breadchaincoop/eigenlayer:dev
     depends_on:
       ethereum:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
 
   eigenlayer:
     platform: linux/amd64
-    image: ghcr.io/breadchaincoop/eigenlayer:dev
+    # Using Sepolia-compatible image from PR #24
+    image: ghcr.io/breadchaincoop/eigenlayer:pr-RonTuretzky-sepolia-support-9fa6816
     depends_on:
       ethereum:
         condition: service_started

--- a/example.env
+++ b/example.env
@@ -5,16 +5,16 @@
 # =============================================================================
 # Network Configuration
 # =============================================================================
-# For TESTNET mode (Holesky)
-HTTP_RPC=https://ethereum-holesky.publicnode.com # change to private rpc
-WS_RPC=wss://ethereum-holesky.publicnode.com # change to private websocket
-RPC_URL=https://ethereum-holesky.publicnode.com # For Docker containers
+# For TESTNET mode (Sepolia)
+HTTP_RPC=https://ethereum-sepolia-rpc.publicnode.com # change to private rpc
+WS_RPC=wss://ethereum-sepolia-rpc.publicnode.com # change to private websocket
+RPC_URL=https://ethereum-sepolia-rpc.publicnode.com # For Docker containers
 
 # For LOCAL mode (uncomment these)
 # HTTP_RPC=http://localhost:8545
 # WS_RPC=ws://localhost:8545
 # RPC_URL=http://ethereum:8545  # Docker internal network
-# FORK_URL=https://ethereum-holesky.publicnode.com  # Fork from Holesky for local testing
+# FORK_URL=https://ethereum-sepolia-rpc.publicnode.com  # Fork from Sepolia for local testing
 
 # =============================================================================
 # Environment Mode
@@ -35,16 +35,16 @@ ENVIRONMENT=LOCAL
 
 
 # =============================================================================
-# EigenLayer Contract Addresses (Holesky Testnet)
+# EigenLayer Contract Addresses (Sepolia Testnet)
 # =============================================================================
 # Uncomment for TESTNET mode, leave commented for LOCAL mode (will be auto-deployed)
-#DELEGATION_MANAGER_ADDRESS=0xA44151489861Fe9e3055d95adC98FbD462B948e7
-#STRATEGY_MANAGER_ADDRESS=0xdfB5f6CE42aAA7830E94ECFCcAd411beF4d4D5b6
-#LST_CONTRACT_ADDRESS=0x3F1c547b21f65e10480dE3ad8E19fAAC46C95034
-#LST_STRATEGY_ADDRESS=0x7D704507b76571a51d9caE8AdDAbBFd0ba0e63d3
-#BLS_SIGNATURE_CHECKER_ADDRESS=0xca249215e082e17c12bb3c4881839a3f883e5c6b
-#OPERATOR_STATE_RETRIEVER_ADDRESS=0xB4baAfee917fb4449f5ec64804217bccE9f46C67
-#ALLOCATION_MANAGER_ADDRESS=0x78469728304326CBc65f8f95FA756B0B73164462
+#DELEGATION_MANAGER_ADDRESS=0xD4A7E1Bd8015057293f0D0A557088c286942e84b
+#STRATEGY_MANAGER_ADDRESS=0x2E3D6c0744b10eb0A4e6F679F71554a39Ec47a5D
+#LST_CONTRACT_ADDRESS=0x00c71b0fcadE911B2feeE9912DE4Fe19eB04ca56
+#LST_STRATEGY_ADDRESS=0x8b29d91e67b013e855EaFe0ad704aC4Ab086a574
+#BLS_SIGNATURE_CHECKER_ADDRESS=
+#OPERATOR_STATE_RETRIEVER_ADDRESS=
+#ALLOCATION_MANAGER_ADDRESS=0x42583067658071247ec8CE0A516A58f682002d07
 
 # =============================================================================
 # Contract Deployment Configuration

--- a/router/README.md
+++ b/router/README.md
@@ -34,7 +34,7 @@ Required environment variables:
 - `WS_RPC`: WebSocket RPC endpoint
 - `AVS_DEPLOYMENT_PATH`: Path to deployment JSON file
 - `CONTRIBUTOR_X_KEYFILE`: BLS key files for contributors
-- `PRIVATE_KEY`: Private key for transactions. **NOTE:** Address must be funded on Holesky testnet
+- `PRIVATE_KEY`: Private key for transactions. **NOTE:** Address must be funded on Sepolia testnet
 
 Optional environment variables:
 - `AGGREGATION_FREQUENCY`: Signature aggregation frequency in seconds, supports fractional values (default: 30)

--- a/scripts/router_e2e_local.sh
+++ b/scripts/router_e2e_local.sh
@@ -55,7 +55,7 @@ DEFAULT_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf
 sed -i '' "s|^PRIVATE_KEY=.*|PRIVATE_KEY=$DEFAULT_PRIVATE_KEY|" .env
 sed -i '' "s|^FUNDED_KEY=.*|FUNDED_KEY=$DEFAULT_PRIVATE_KEY|" .env
 
-# Set Holesky contract addresses for LOCAL mode
+# Set Sepolia contract addresses for LOCAL mode
 sed -i '' 's|^#DELEGATION_MANAGER_ADDRESS=|DELEGATION_MANAGER_ADDRESS=|' .env
 sed -i '' 's|^#STRATEGY_MANAGER_ADDRESS=|STRATEGY_MANAGER_ADDRESS=|' .env
 sed -i '' 's|^#LST_CONTRACT_ADDRESS=|LST_CONTRACT_ADDRESS=|' .env

--- a/usecases/src/eigenlayer/network.rs
+++ b/usecases/src/eigenlayer/network.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256, address};
+use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use commonware_avs_core::bn254::{G1PublicKey, PublicKey};
 use eigen_client_avsregistry::reader::AvsRegistryChainReader;
@@ -75,23 +75,19 @@ pub struct QuorumInfo {
     pub operators: Vec<OperatorInfo>,
 }
 
-/// source: https://github.com/Layr-Labs/eigenlayer-middleware
-/// Contracts from middleware are supposed to be deployed for each AVS but
-/// OperatorStateRetriever looks generic for everyone.
-const OPERATOR_STATE_RETRIEVER_ADDRESS: Address =
-    address!("0xB4baAfee917fb4449f5ec64804217bccE9f46C67"); // TODO Add handling for different chains
-
 pub struct EigenStakingClient {
     http_endpoint: String,
     registry_coordinator_address: Address,
     registry_coordinator_deploy_block: u64,
     operator_info_service: Arc<OperatorInfoServiceInMemory>,
+    operator_state_retriever_address: Address,
 }
 
 #[derive(Debug)]
 pub struct AvsDeploymentConfig {
     pub registry_coordinator_address: Address,
     pub deploy_block: u64,
+    pub operator_state_retriever_address: Address,
 }
 
 impl EigenStakingClient {
@@ -109,6 +105,13 @@ impl EigenStakingClient {
             .as_str()
             .ok_or("Missing registryCoordinator address")?;
 
+        // Read operator state retriever address from blsSigCheck field
+        // This is the BLSSigCheckOperatorStateRetriever which implements
+        // both signature checking and operator state retrieval
+        let operator_state_retriever = addresses["blsSigCheck"]
+            .as_str()
+            .ok_or("Missing blsSigCheck address")?;
+
         let last_update = json["lastUpdate"]
             .as_object()
             .ok_or("Missing lastUpdate in deployment config")?;
@@ -118,13 +121,18 @@ impl EigenStakingClient {
             .ok_or("Missing block_number in lastUpdate")?
             .parse::<u64>()?;
 
-        let address = registry_coordinator
+        let registry_coordinator_address = registry_coordinator
             .parse::<Address>()
             .map_err(|_| "Failed to parse registry coordinator address")?;
 
+        let operator_state_retriever_address = operator_state_retriever
+            .parse::<Address>()
+            .map_err(|_| "Failed to parse operator state retriever address")?;
+
         Ok(AvsDeploymentConfig {
-            registry_coordinator_address: address,
+            registry_coordinator_address,
             deploy_block,
+            operator_state_retriever_address,
         })
     }
 
@@ -136,7 +144,7 @@ impl EigenStakingClient {
         let config = Self::read_avs_deployment_config(&avs_deployment_path)?;
         let avs_registry_reader = AvsRegistryChainReader::new(
             config.registry_coordinator_address,
-            OPERATOR_STATE_RETRIEVER_ADDRESS,
+            config.operator_state_retriever_address,
             http_endpoint.clone(),
         )
         .await?;
@@ -150,6 +158,7 @@ impl EigenStakingClient {
             registry_coordinator_address: config.registry_coordinator_address,
             registry_coordinator_deploy_block: config.deploy_block,
             operator_info_service: Arc::new(operator_info_service),
+            operator_state_retriever_address: config.operator_state_retriever_address,
         })
     }
 
@@ -164,9 +173,9 @@ impl EigenStakingClient {
             )
             .await?;
 
-        // Query operator states
+        // Query operator states using the dynamic address from config
         let operator_state_retriever =
-            OperatorStateRetriever::new(OPERATOR_STATE_RETRIEVER_ADDRESS, provider);
+            OperatorStateRetriever::new(self.operator_state_retriever_address, provider);
         let quorum_numbers: Vec<u8> = vec![0];
         let operators_state = operator_state_retriever
             .getOperatorState_0(


### PR DESCRIPTION
## Summary
- Replace hardcoded Holesky OperatorStateRetriever address with dynamic loading from `blsSigCheck` field
- Enables EigenStakingClient to work with any chain/deployment (Sepolia, local testnets, etc.)

## Changes
- Remove hardcoded `OPERATOR_STATE_RETRIEVER_ADDRESS` constant
- Add `operator_state_retriever_address` to `AvsDeploymentConfig`
- Read `blsSigCheck` field from avs_deploy.json
- Store and use the dynamic address in `EigenStakingClient`

## Context
This fixes CI failures in gas-killer-router when running on Sepolia fork where the BLSSigCheckOperatorStateRetriever is deployed at a different address than Holesky.