### PR TITLE
Add a break after execution so additional signatures after threshold do not retrigger

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -53,3 +53,4 @@ prost-build = { workspace = true }
 
 [dev-dependencies]
 commonware-avs-core = { path = "../core", features = ["test-utils"] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/router/src/executor/tests/mock.rs
+++ b/router/src/executor/tests/mock.rs
@@ -152,6 +152,14 @@ where
         *self.execution_count.lock().unwrap()
     }
 
+    /// Returns a shared handle to the execution counter.
+    ///
+    /// Callers can clone this before moving the executor into the orchestrator
+    /// and read the count from outside after execution.
+    pub fn execution_count_handle(&self) -> Arc<Mutex<u64>> {
+        self.execution_count.clone()
+    }
+
     /// Resets the execution count to zero.
     ///
     /// This method is useful for testing to reset the counter

--- a/router/src/orchestrator/tests/helpers/contributor.rs
+++ b/router/src/orchestrator/tests/helpers/contributor.rs
@@ -4,6 +4,29 @@ use commonware_cryptography::Signer;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// Like `create_test_contributors` but also returns the signers so tests can produce
+/// valid BLS signatures over a known digest.
+pub fn create_test_contributors_with_signers()
+-> (Vec<PublicKey>, HashMap<PublicKey, G1PublicKey>, Vec<Bn254>) {
+    let mut contributors = Vec::new();
+    let mut g1_map = HashMap::new();
+    let mut signers = Vec::new();
+
+    for i in 0..3 {
+        let fr = Fr::from_str(&format!("{}", i + 1000)).expect("Failed to create test Fr");
+        let private_key = PrivateKey::from(fr);
+        let signer = Bn254::new(private_key).expect("Failed to create contributor signer");
+        let pub_key = signer.public_key();
+        let g1_pub_key = signer.public_g1();
+
+        contributors.push(pub_key.clone());
+        g1_map.insert(pub_key, g1_pub_key);
+        signers.push(signer);
+    }
+
+    (contributors, g1_map, signers)
+}
+
 /// Helper function to create test contributors for testing purposes.
 ///
 /// This function creates a set of test contributors with their

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -3,11 +3,13 @@ use crate::creator::Creator;
 use crate::creator::MockCreator;
 use crate::executor::MockExecutor;
 use crate::orchestrator::builder::OrchestratorBuilder;
+use crate::orchestrator::traits::OrchestratorTrait;
 use commonware_avs_core::validator::MockValidator;
 use std::time::Duration;
 
 use super::helpers::{contributor, signer};
 use super::mocks::clock::MockClock;
+use super::mocks::{MockReceiver, MockSender};
 
 #[tokio::test]
 async fn test_orchestrator_builder_integration() {
@@ -262,4 +264,87 @@ async fn test_orchestrator_component_interaction() {
     // Test validator interaction
     let validator_ref = orchestrator.validator();
     assert_eq!(validator_ref.get_validation_count(), 0);
+}
+
+/// Verify that execution fires exactly once for a round even when more signatures arrive
+/// after the threshold has been reached.
+///
+/// Uses `start_paused = true` so `tokio::time::sleep` in MockClock::sleep_until is controlled
+/// by `tokio::time::advance` rather than real wall time.
+#[tokio::test(start_paused = true)]
+async fn test_executor_called_exactly_once_after_threshold() {
+    use alloy::primitives::U256;
+    use alloy::sol_types::SolValue;
+    use bytes::Bytes;
+    use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
+    use commonware_codec::{EncodeSize, Write};
+    use commonware_cryptography::{Hasher, Sha256, Signer};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map, contributor_signers) =
+        contributor::create_test_contributors_with_signers();
+
+    // threshold=2, 3 contributors → we will send 3 signatures so execution fires at #2 and #3
+    // is ignored.
+    let builder = OrchestratorBuilder::new(clock, orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_aggregation_frequency(Duration::from_millis(100));
+
+    let executor = MockExecutor::new();
+    let exec_count = executor.execution_count_handle();
+    let validator = MockValidator::new_success(1);
+
+    let orchestrator = builder
+        .build(MockCreator::<TestTaskData>::new(), executor, validator)
+        .expect("failed to build orchestrator");
+
+    // MockValidator::new_success(1) ignores the message bytes and always returns
+    // Sha256(U256::from(1).abi_encode()). Reproduce the same digest so we can sign it.
+    let expected_digest = {
+        let payload = U256::from(1u64).abi_encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        hasher.finalize()
+    };
+
+    // Enqueue threshold+1 = 3 signed messages for round 1 before the orchestrator starts.
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+    for contributor_signer in &contributor_signers {
+        let sig = contributor_signer.sign(None, expected_digest.as_ref());
+        let msg = Aggregation::<TestTaskData>::new(
+            1,
+            TestTaskData::default(),
+            Some(Payload::Signature(sig.to_vec())),
+        );
+        let mut buf = Vec::with_capacity(msg.encode_size());
+        msg.write(&mut buf);
+        msg_tx
+            .send((contributor_signer.public_key(), Bytes::from(buf)))
+            .unwrap();
+    }
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Keep msg_tx alive until after advancing time so the receiver stays open (Pending rather
+    // than Err) once the channel drains, letting the inner select! block on it rather than
+    // spinning on errors until the timer fires.
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        *exec_count.lock().unwrap(),
+        1,
+        "executor should fire exactly once at threshold"
+    );
+
+    drop(msg_tx);
+    handle.abort();
 }

--- a/router/src/orchestrator/tests/mocks/mod.rs
+++ b/router/src/orchestrator/tests/mocks/mod.rs
@@ -1,1 +1,68 @@
 pub mod clock;
+
+use bytes::Bytes;
+use commonware_avs_core::bn254::PublicKey;
+use commonware_p2p::{Receiver, Recipients, Sender};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+#[derive(Debug)]
+pub struct MockP2pError;
+
+impl fmt::Display for MockP2pError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "mock p2p error")
+    }
+}
+
+impl std::error::Error for MockP2pError {}
+
+/// Minimal no-op sender that satisfies the `Sender` trait bounds.
+#[derive(Clone, Debug)]
+pub struct MockSender;
+
+impl MockSender {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Sender for MockSender {
+    type Error = MockP2pError;
+    type PublicKey = PublicKey;
+
+    async fn send(
+        &mut self,
+        _recipients: Recipients<PublicKey>,
+        _message: Bytes,
+        _priority: bool,
+    ) -> Result<Vec<PublicKey>, MockP2pError> {
+        Ok(vec![])
+    }
+}
+
+/// Channel-backed receiver that lets tests inject messages into the run loop.
+pub struct MockReceiver {
+    rx: UnboundedReceiver<(PublicKey, Bytes)>,
+}
+
+impl MockReceiver {
+    pub fn new(rx: UnboundedReceiver<(PublicKey, Bytes)>) -> Self {
+        Self { rx }
+    }
+}
+
+impl fmt::Debug for MockReceiver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MockReceiver")
+    }
+}
+
+impl Receiver for MockReceiver {
+    type Error = MockP2pError;
+    type PublicKey = PublicKey;
+
+    async fn recv(&mut self) -> Result<(PublicKey, Bytes), MockP2pError> {
+        self.rx.recv().await.ok_or(MockP2pError)
+    }
+}

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -140,10 +140,9 @@ where
                 "generated payload for state"
             );
 
-            // Skip broadcasting for already-executed rounds
+            // Skip broadcasting for already-executed rounds; poll on a short interval until next round.
             if executed_rounds.contains(&current_round) {
-                let continue_time = self.runtime.current() + self.aggregation_frequency;
-                self.runtime.sleep_until(continue_time).await;
+                self.runtime.sleep(Duration::from_secs(2)).await;
                 continue;
             }
 

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -265,7 +265,7 @@ where
                         // Aggregate signatures
                         let mut participating = Vec::new();
                         let mut participating_g1 = Vec::new();
-                        let mut signatures = Vec::new();
+                        let mut agg_signatures = Vec::new();
                         for i in 0..self.contributors.len() {
                             let Some(signature) = round.get(&i) else {
                                 continue;
@@ -274,9 +274,9 @@ where
                             let g1_pubkey : G1PublicKey= self.g1_map[contributor].clone();
                             participating_g1.push(g1_pubkey.clone());
                             participating.push(contributor.clone());
-                            signatures.push(signature.clone());
+                            agg_signatures.push(signature.clone());
                         }
-                        let agg_signature = aggregate_signatures(&signatures).unwrap();
+                        let agg_signature = aggregate_signatures(&agg_signatures).unwrap();
 
                         // Verify aggregated signature (already verified individual signatures so should never fail)
                         if !aggregate_verify(&participating, None, &expected_digest, &agg_signature) {
@@ -285,7 +285,7 @@ where
 
                         // Execute verification with the aggregated signature
                         // Serialize BLS-specific types to bytes for generic VerificationData
-                        let serialized_signatures: Vec<Vec<u8>> = signatures.iter().map(|s| s.to_vec()).collect();
+                        let serialized_signatures: Vec<Vec<u8>> = agg_signatures.iter().map(|s| s.to_vec()).collect();
                         let serialized_public_keys: Vec<Vec<u8>> = participating.iter().map(|pk| pk.to_vec()).collect();
 
                         // Serialize G1 public keys to context
@@ -318,8 +318,14 @@ where
                             }
                         }
 
+                        // Drop per-round signature state now that this round has finished.
+                        signatures.remove(&msg.round);
                         // Mark round complete so additional signatures are ignored and the outer
                         // loop does not re-broadcast Start while waiting for on-chain state to advance.
+                        //
+                        // Rounds advance monotonically, so only the latest executed round needs to
+                        // be retained to suppress duplicate processing without unbounded growth.
+                        executed_rounds.clear();
                         executed_rounds.insert(msg.round);
                     },
                 }

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -314,6 +314,15 @@ where
                                     "Successfully executed verification with aggregated signature. Result: {:?}",
                                     result
                                 );
+                                // Drop per-round signature state now that this round has finished.
+                                signatures.remove(&msg.round);
+                                // Mark round complete so additional signatures are ignored and the outer
+                                // loop does not re-broadcast Start while waiting for on-chain state to advance.
+                                //
+                                // Rounds advance monotonically, so only the latest executed round needs to
+                                // be retained to suppress duplicate processing without unbounded growth.
+                                executed_rounds.clear();
+                                executed_rounds.insert(msg.round);
                             },
                             Err(e) => {
                                 info!(
@@ -321,18 +330,10 @@ where
                                     "Failed to execute verification with aggregated signature: {:?}",
                                     e
                                 );
+                                // Leave the round open so a subsequent signature above threshold
+                                // can retrigger execution.
                             }
                         }
-
-                        // Drop per-round signature state now that this round has finished.
-                        signatures.remove(&msg.round);
-                        // Mark round complete so additional signatures are ignored and the outer
-                        // loop does not re-broadcast Start while waiting for on-chain state to advance.
-                        //
-                        // Rounds advance monotonically, so only the latest executed round needs to
-                        // be retained to suppress duplicate processing without unbounded growth.
-                        executed_rounds.clear();
-                        executed_rounds.insert(msg.round);
                     },
                 }
             }

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -11,7 +11,10 @@ use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
 use commonware_runtime::Clock;
 use commonware_utils::hex;
-use std::{collections::{HashMap, HashSet}, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 use tracing::info;
 
 use crate::creator::Creator;

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -303,6 +303,9 @@ where
                                 );
                             }
                         }
+
+                        // Prevents additional signatures after threshold from re-triggering execution on an already-completed round.
+                        break;
                     },
                 }
             }

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -143,9 +143,15 @@ where
                 "generated payload for state"
             );
 
-            // Skip broadcasting for already-executed rounds; poll on a short interval until next round.
+            // Skip broadcasting for already-executed rounds, but keep servicing the receiver
+            // so late signatures/messages for completed rounds do not build up in the buffer.
             if executed_rounds.contains(&current_round) {
-                self.runtime.sleep(Duration::from_secs(2)).await;
+                select! {
+                    _ = self.runtime.sleep(Duration::from_secs(2)) => {},
+                    received = receiver.recv() => {
+                        let _ = received;
+                    },
+                }
                 continue;
             }
 

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -11,7 +11,7 @@ use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
 use commonware_runtime::Clock;
 use commonware_utils::hex;
-use std::{collections::HashMap, time::Duration};
+use std::{collections::{HashMap, HashSet}, time::Duration};
 use tracing::info;
 
 use crate::creator::Creator;
@@ -125,6 +125,7 @@ where
         mut receiver: impl Receiver<PublicKey = PublicKey>,
     ) {
         let mut signatures = HashMap::new();
+        let mut executed_rounds: HashSet<u64> = HashSet::new();
 
         loop {
             let (payload, current_round) = self.task_creator.get_payload_and_round().await.unwrap();
@@ -138,6 +139,13 @@ where
                 msg = hex(&payload),
                 "generated payload for state"
             );
+
+            // Skip broadcasting for already-executed rounds
+            if executed_rounds.contains(&current_round) {
+                let continue_time = self.runtime.current() + self.aggregation_frequency;
+                self.runtime.sleep_until(continue_time).await;
+                continue;
+            }
 
             // Broadcast payload
             let task_data = self.task_creator.get_task_metadata();
@@ -186,6 +194,10 @@ where
                             info!("Failed to decode message from sender: {:?}", sender);
                             continue;
                         };
+                        if executed_rounds.contains(&msg.round) {
+                            info!("Ignoring signature for already-executed round: {} from contributor: {:?}", msg.round, contributor);
+                            continue;
+                        }
                         let Some(round) = signatures.get_mut(&msg.round) else {
                             info!("Received signature for unknown round: {} from contributor: {:?}", msg.round, contributor);
                             continue;
@@ -304,8 +316,9 @@ where
                             }
                         }
 
-                        // Prevents additional signatures after threshold from re-triggering execution on an already-completed round.
-                        break;
+                        // Mark round complete so additional signatures are ignored and the outer
+                        // loop does not re-broadcast Start while waiting for on-chain state to advance.
+                        executed_rounds.insert(msg.round);
                     },
                 }
             }


### PR DESCRIPTION
Without this break statement, any signature that comes in after a threshold is met will trigger an additional execution. We didn't encounter this error before because we had quorum set to 3/3 but with the updated 2/3 approach it becomes an issue.