### PR TITLE
fix: unblock queued-task throughput in orchestrator loop (break after execution)

### DIFF
--- a/example.env
+++ b/example.env
@@ -17,6 +17,22 @@ RPC_URL=https://ethereum-sepolia-rpc.publicnode.com # For Docker containers
 # FORK_URL=https://ethereum-sepolia-rpc.publicnode.com  # Fork from Sepolia for local testing
 
 # =============================================================================
+# AVS Service Manager Wrapper Configuration
+# =============================================================================
+# These values are passed as immutable constructor parameters when deploying
+# AvsServiceManagerWrapper and CANNOT be changed after deployment.
+#
+# QUORUM_THRESHOLD / THRESHOLD_DENOMINATOR: fraction of total registered
+# operator stake that must sign a task for it to be accepted. 2/3 means at
+# least two-thirds of stake-weighted operators must co-sign.
+#
+# BLOCK_STALE_MEASURE: maximum age (in blocks) of a valid reference block.
+# At ~12 s/block on Ethereum, 300 blocks ≈ 1 hour.
+QUORUM_THRESHOLD=2
+THRESHOLD_DENOMINATOR=3
+BLOCK_STALE_MEASURE=300
+
+# =============================================================================
 # Environment Mode
 # =============================================================================
 ENVIRONMENT=LOCAL

--- a/example.env
+++ b/example.env
@@ -19,8 +19,9 @@ RPC_URL=https://ethereum-sepolia-rpc.publicnode.com # For Docker containers
 # =============================================================================
 # AVS Service Manager Wrapper Configuration
 # =============================================================================
-# These values are passed as immutable constructor parameters when deploying
-# AvsServiceManagerWrapper and CANNOT be changed after deployment.
+ # If your deployment tooling supports it, these values can be passed as immutable
+ # constructor parameters when deploying AvsServiceManagerWrapper and cannot be
+ # changed after deployment. (They are not consumed directly by the Rust services.)
 #
 # QUORUM_THRESHOLD / THRESHOLD_DENOMINATOR: fraction of total registered
 # operator stake that must sign a task for it to be accepted. 2/3 means at

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -324,10 +324,10 @@ where
                                 executed_rounds.clear();
                                 executed_rounds.insert(msg.round);
                                 // Return to the outer loop immediately so the next queued task is
-                                // fetched without waiting out `aggregation_frequency`. A chain-polling
-                                // creator that re-returns this same round is debounced by the
-                                // `executed_rounds` 2s-sleep branch at the top of the outer loop;
-                                // a queue/channel creator gets a fresh round and broadcasts at once.
+                                // fetched without waiting out `aggregation_frequency`. If a chain-polling
+                                // creator re-returns this same round, the `executed_rounds` branch at the
+                                // top of the outer loop avoids re-broadcasting Start (sleeping up to 2s
+                                // when idle while still draining the receiver to prevent buffer build-up).
                                 break;
                             },
                             Err(e) => {

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -323,6 +323,12 @@ where
                                 // be retained to suppress duplicate processing without unbounded growth.
                                 executed_rounds.clear();
                                 executed_rounds.insert(msg.round);
+                                // Return to the outer loop immediately so the next queued task is
+                                // fetched without waiting out `aggregation_frequency`. A chain-polling
+                                // creator that re-returns this same round is debounced by the
+                                // `executed_rounds` 2s-sleep branch at the top of the outer loop;
+                                // a queue/channel creator gets a fresh round and broadcasts at once.
+                                break;
                             },
                             Err(e) => {
                                 info!(


### PR DESCRIPTION
## Problem

Under queued/back-to-back load, the generic orchestrator processed only **one round per `aggregation_frequency`**. After a successful execution, the inner signature-collection loop fell through to `sleep_until(now + aggregation_frequency)` before the outer loop could fetch the next task. With the gas-killer deployment's `AGGREGATION_FREQUENCY=1200`, that capped sustained throughput at ~3 rounds/hour regardless of arrival rate or per-round cost.

Detailed analysis + evidence: BreadchainCoop/commonware-restaking#158.

## Change

The net effect of this branch on the orchestrator round loop:

- **`break` after a successful execution** — return to the outer loop immediately so the next queued task is fetched without waiting out `aggregation_frequency`.
- **Chain-polling creators stay correct** — one that re-returns the same round is debounced by the existing `executed_rounds` 2s-sleep branch at the top of the outer loop; a queue/channel creator gets a fresh round and broadcasts at once.
- **Only mark a round complete on execution success** — on failure the round is left open so a later signature can retrigger.
- Per-round signature state is dropped after completion; the receiver keeps being serviced to avoid buffer buildup.
- New integration coverage, including `test_executor_called_exactly_once_after_threshold` (late post-threshold signatures must not retrigger execution).

## Evidence (gas-killer local stack, 3 operators, threshold 2, 20-task burst)

| `aggregation_frequency` | Result | Throughput |
|---|---|---|
| 1200s (pre-fix behavior) | 1/20 rounds, then stalled 10+ min | ~0.05 rounds/min |
| 10s (approximates this fix) | 20/20 in ~150s | ~8 rounds/min |

Inter-round gap tracked the window almost exactly (10.2s at a 10s window) while real per-round work was ~0.2s — i.e. the wait was almost entirely idle. With the `break`, inter-round time drops from `aggregation_frequency` to ~the work.

## Tests

`cargo test -p commonware-avs-router orchestrator` → 28 passed, 0 failed, including `test_executor_called_exactly_once_after_threshold`.

Closes BreadchainCoop/commonware-restaking#158
