### PR TITLE
Pass typed `BlsVerificationData` to executor to skip serde round-trip

### DIFF
--- a/router/src/executor/bls/executor.rs
+++ b/router/src/executor/bls/executor.rs
@@ -104,7 +104,7 @@ impl<H: BlsSignatureVerificationHandler> VerificationExecutor<H::TaskData, Verif
             .signatures
             .iter()
             .map(|bytes| {
-                Signature::try_from(bytes.as_slice())
+                Signature::try_from(bytes.as_ref())
                     .map_err(|e| anyhow::anyhow!("Failed to deserialize signature: {:?}", e))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -114,7 +114,7 @@ impl<H: BlsSignatureVerificationHandler> VerificationExecutor<H::TaskData, Verif
             .public_keys
             .iter()
             .map(|bytes| {
-                PublicKey::try_from(bytes.as_slice())
+                PublicKey::try_from(bytes.as_ref())
                     .map_err(|e| anyhow::anyhow!("Failed to deserialize public key: {:?}", e))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -153,6 +153,22 @@ impl<H: BlsSignatureVerificationHandler> VerificationExecutor<H::TaskData, Verif
             BlsVerificationData::new(signatures, public_keys, g1_public_keys);
 
         self.execute_bls_verification(payload_hash, bls_verification_data, task_data)
+            .await
+    }
+}
+
+/// Runs BLS verification on the provided `BlsVerificationData`.
+#[async_trait]
+impl<H: BlsSignatureVerificationHandler> VerificationExecutor<H::TaskData, BlsVerificationData>
+    for BlsEigenlayerExecutor<H>
+{
+    async fn execute_verification(
+        &mut self,
+        payload_hash: &[u8],
+        verification_data: BlsVerificationData,
+        task_data: Option<&H::TaskData>,
+    ) -> Result<ExecutionResult> {
+        self.execute_bls_verification(payload_hash, verification_data, task_data)
             .await
     }
 }

--- a/router/src/executor/bls/mod.rs
+++ b/router/src/executor/bls/mod.rs
@@ -5,6 +5,7 @@ pub mod utils;
 
 pub use executor::BlsEigenlayerExecutor;
 pub use traits::BlsSignatureVerificationHandler;
+pub use types::BlsVerificationData;
 pub use utils::convert_non_signer_data;
 
 #[cfg(test)]

--- a/router/src/executor/bls/types.rs
+++ b/router/src/executor/bls/types.rs
@@ -1,5 +1,7 @@
 use commonware_avs_core::bn254::{G1PublicKey, PublicKey, Signature};
 
+use crate::executor::traits::FromBlsAggregation;
+
 /// BLS-specific verification data that includes G1 public keys
 #[derive(Debug, Clone)]
 pub struct BlsVerificationData {
@@ -19,5 +21,15 @@ impl BlsVerificationData {
             public_keys,
             g1_public_keys,
         }
+    }
+}
+
+impl FromBlsAggregation for BlsVerificationData {
+    fn from_bls_aggregation(
+        signatures: Vec<Signature>,
+        public_keys: Vec<PublicKey>,
+        g1_public_keys: Vec<G1PublicKey>,
+    ) -> Self {
+        Self::new(signatures, public_keys, g1_public_keys)
     }
 }

--- a/router/src/executor/mod.rs
+++ b/router/src/executor/mod.rs
@@ -3,7 +3,7 @@ pub mod traits;
 pub mod types;
 
 pub use bls::{BlsEigenlayerExecutor, convert_non_signer_data};
-pub use traits::VerificationExecutor;
+pub use traits::{FromBlsAggregation, VerificationExecutor};
 pub use types::{ExecutionResult, VerificationData};
 
 #[cfg(test)]

--- a/router/src/executor/traits.rs
+++ b/router/src/executor/traits.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use commonware_avs_core::bn254::{G1PublicKey, PublicKey, Signature};
 
 use crate::executor::types::ExecutionResult;
 
@@ -15,4 +16,14 @@ where
         verification_data: V,
         task_data: Option<&T>,
     ) -> Result<ExecutionResult>;
+}
+
+/// Builds a verification-data container from BLS aggregation output: the per-signer
+/// signatures, their public keys, and their G1 public keys.
+pub trait FromBlsAggregation {
+    fn from_bls_aggregation(
+        signatures: Vec<Signature>,
+        public_keys: Vec<PublicKey>,
+        g1_public_keys: Vec<G1PublicKey>,
+    ) -> Self;
 }

--- a/router/src/executor/types.rs
+++ b/router/src/executor/types.rs
@@ -1,17 +1,22 @@
+use bytes::Bytes;
+use commonware_avs_core::bn254::{G1PublicKey, PublicKey, Signature};
+
+use crate::executor::traits::FromBlsAggregation;
+
 /// Generic verification data that can be used by different verification methods
 ///
 /// This type is executor-agnostic and can be converted to executor-specific
 /// types by the executor implementation.
 #[derive(Debug, Clone)]
 pub struct VerificationData {
-    pub signatures: Vec<Vec<u8>>,
-    pub public_keys: Vec<Vec<u8>>,
+    pub signatures: Vec<Bytes>,
+    pub public_keys: Vec<Bytes>,
     /// Additional context data that might be needed by specific verification methods
-    pub context: Option<Vec<u8>>,
+    pub context: Option<Bytes>,
 }
 
 impl VerificationData {
-    pub fn new(signatures: Vec<Vec<u8>>, public_keys: Vec<Vec<u8>>) -> Self {
+    pub fn new(signatures: Vec<Bytes>, public_keys: Vec<Bytes>) -> Self {
         Self {
             signatures,
             public_keys,
@@ -19,9 +24,28 @@ impl VerificationData {
         }
     }
 
-    pub fn with_context(mut self, context: Vec<u8>) -> Self {
+    pub fn with_context(mut self, context: Bytes) -> Self {
         self.context = Some(context);
         self
+    }
+}
+
+impl FromBlsAggregation for VerificationData {
+    fn from_bls_aggregation(
+        signatures: Vec<Signature>,
+        public_keys: Vec<PublicKey>,
+        g1_public_keys: Vec<G1PublicKey>,
+    ) -> Self {
+        let signatures = signatures.iter().map(|s| Bytes::from(s.to_vec())).collect();
+        let public_keys = public_keys
+            .iter()
+            .map(|pk| Bytes::from(pk.to_vec()))
+            .collect();
+        let mut context = Vec::new();
+        for g1_pubkey in &g1_public_keys {
+            context.extend_from_slice(g1_pubkey);
+        }
+        Self::new(signatures, public_keys).with_context(Bytes::from(context))
     }
 }
 

--- a/router/src/executor/types.rs
+++ b/router/src/executor/types.rs
@@ -41,7 +41,7 @@ impl FromBlsAggregation for VerificationData {
             .iter()
             .map(|pk| Bytes::from(pk.to_vec()))
             .collect();
-        let mut context = Vec::new();
+        let mut context = Vec::with_capacity(g1_public_keys.iter().map(|g1| g1.len()).sum());
         for g1_pubkey in &g1_public_keys {
             context.extend_from_slice(g1_pubkey);
         }

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -5,7 +5,12 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tracing::info;
 
-use crate::executor::{VerificationData, VerificationExecutor};
+use crate::executor::{FromBlsAggregation, VerificationData, VerificationExecutor};
+
+/// Fallible orchestrator construction, parameterized by the verification-data container
+/// `VD` the executor consumes.
+type OrchestratorBuildResult<TC, E, V, C, VD> =
+    Result<crate::orchestrator::types::Orchestrator<TC, E, V, C, VD>, Box<dyn std::error::Error>>;
 
 /// Configuration bundle returned by the orchestrator builder
 #[allow(dead_code)]
@@ -255,11 +260,27 @@ impl<C: Clock> OrchestratorBuilder<C> {
         task_creator: TC,
         executor: E,
         validator: V,
-    ) -> Result<crate::orchestrator::types::Orchestrator<TC, E, V, C>, Box<dyn std::error::Error>>
+    ) -> OrchestratorBuildResult<TC, E, V, C, VerificationData>
     where
         TC: crate::creator::Creator + Send + Sync,
         E: VerificationExecutor<TC::TaskData, VerificationData> + Send + Sync,
         V: ValidatorTrait + Send + Sync,
+    {
+        self.build_with::<TC, E, V, VerificationData>(task_creator, executor, validator)
+    }
+
+    /// Builds an orchestrator whose executor consumes the verification-data container `VD`.
+    pub fn build_with<TC, E, V, VD>(
+        self,
+        task_creator: TC,
+        executor: E,
+        validator: V,
+    ) -> OrchestratorBuildResult<TC, E, V, C, VD>
+    where
+        TC: crate::creator::Creator + Send + Sync,
+        E: VerificationExecutor<TC::TaskData, VD> + Send + Sync,
+        V: ValidatorTrait + Send + Sync,
+        VD: FromBlsAggregation + Send + Sync,
     {
         self.validate()?;
 

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -1,10 +1,13 @@
 use super::task_data::TestTaskData;
 use crate::creator::Creator;
 use crate::creator::MockCreator;
-use crate::executor::MockExecutor;
+use crate::executor::bls::BlsVerificationData;
+use crate::executor::{ExecutionResult, MockExecutor, VerificationExecutor};
 use crate::orchestrator::builder::OrchestratorBuilder;
 use crate::orchestrator::traits::OrchestratorTrait;
+use async_trait::async_trait;
 use commonware_avs_core::validator::MockValidator;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::helpers::{contributor, signer};
@@ -343,6 +346,116 @@ async fn test_executor_called_exactly_once_after_threshold() {
         *exec_count.lock().unwrap(),
         1,
         "executor should fire exactly once at threshold"
+    );
+
+    drop(msg_tx);
+    handle.abort();
+}
+
+/// Records the signer counts from each `BlsVerificationData` it receives.
+struct RecordingBlsExecutor {
+    /// (signatures, public_keys, g1_public_keys) counts from the last call.
+    received: Arc<Mutex<Option<(usize, usize, usize)>>>,
+}
+
+#[async_trait]
+impl VerificationExecutor<TestTaskData, BlsVerificationData> for RecordingBlsExecutor {
+    async fn execute_verification(
+        &mut self,
+        _payload_hash: &[u8],
+        verification_data: BlsVerificationData,
+        _task_data: Option<&TestTaskData>,
+    ) -> anyhow::Result<ExecutionResult> {
+        *self.received.lock().unwrap() = Some((
+            verification_data.signatures.len(),
+            verification_data.public_keys.len(),
+            verification_data.g1_public_keys.len(),
+        ));
+        Ok(ExecutionResult {
+            transaction_hash: "typed".to_string(),
+            block_number: None,
+            gas_used: None,
+            status: Some(true),
+            contract_address: None,
+        })
+    }
+}
+
+/// Built with `VD = BlsVerificationData`, the orchestrator delivers one entry per
+/// participating signer to the executor.
+#[tokio::test(start_paused = true)]
+async fn test_orchestrator_passes_typed_bls_data() {
+    use alloy::primitives::U256;
+    use alloy::sol_types::SolValue;
+    use bytes::Bytes;
+    use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
+    use commonware_codec::{EncodeSize, Write};
+    use commonware_cryptography::{Hasher, Sha256, Signer};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map, contributor_signers) =
+        contributor::create_test_contributors_with_signers();
+
+    let builder = OrchestratorBuilder::new(clock, orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_aggregation_frequency(Duration::from_millis(100));
+
+    let received = Arc::new(Mutex::new(None));
+    let executor = RecordingBlsExecutor {
+        received: received.clone(),
+    };
+    let validator = MockValidator::new_success(1);
+
+    let orchestrator = builder
+        .build_with::<_, _, _, BlsVerificationData>(
+            MockCreator::<TestTaskData>::new(),
+            executor,
+            validator,
+        )
+        .expect("failed to build orchestrator");
+
+    // MockValidator::new_success(1) returns Sha256(U256::from(1).abi_encode()) regardless of
+    // the message bytes; reproduce it so the contributor signatures verify and aggregate.
+    let expected_digest = {
+        let payload = U256::from(1u64).abi_encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        hasher.finalize()
+    };
+
+    // Enqueue exactly the threshold (2) signed messages for round 1.
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+    for contributor_signer in contributor_signers.iter().take(2) {
+        let sig = contributor_signer.sign(None, expected_digest.as_ref());
+        let msg = Aggregation::<TestTaskData>::new(
+            1,
+            TestTaskData::default(),
+            Some(Payload::Signature(sig.to_vec())),
+        );
+        let mut buf = Vec::with_capacity(msg.encode_size());
+        msg.write(&mut buf);
+        msg_tx
+            .send((contributor_signer.public_key(), Bytes::from(buf)))
+            .unwrap();
+    }
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        *received.lock().unwrap(),
+        Some((2, 2, 2)),
+        "orchestrator should deliver typed BlsVerificationData with one entry per signer"
     );
 
     drop(msg_tx);

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -13,12 +13,13 @@ use commonware_runtime::Clock;
 use commonware_utils::hex;
 use std::{
     collections::{HashMap, HashSet},
+    marker::PhantomData,
     time::Duration,
 };
 use tracing::info;
 
 use crate::creator::Creator;
-use crate::executor::{VerificationData, VerificationExecutor};
+use crate::executor::{FromBlsAggregation, VerificationData, VerificationExecutor};
 use crate::orchestrator::traits::OrchestratorTrait;
 
 /// Configuration for the generic orchestrator
@@ -42,12 +43,14 @@ pub struct OrchestratorConfig {
 /// * `E` - Executor implementation that implements `VerificationExecutor`
 /// * `V` - Validator implementation that implements `ValidatorTrait`
 /// * `C` - Clock implementation that implements `Clock`
-pub struct Orchestrator<TC, E, V, C>
+/// * `VD` - Verification-data container the executor consumes (defaults to `VerificationData`)
+pub struct Orchestrator<TC, E, V, C, VD = VerificationData>
 where
     TC: Creator,
-    E: VerificationExecutor<TC::TaskData, VerificationData>,
+    E: VerificationExecutor<TC::TaskData, VD>,
     V: ValidatorTrait,
     C: Clock,
+    VD: FromBlsAggregation + Send + Sync,
 {
     runtime: C,
     #[allow(dead_code)]
@@ -60,14 +63,16 @@ where
     task_creator: TC,
     executor: E,
     validator: V,
+    _verification_data: PhantomData<fn() -> VD>,
 }
 
-impl<TC, E, V, C> Orchestrator<TC, E, V, C>
+impl<TC, E, V, C, VD> Orchestrator<TC, E, V, C, VD>
 where
     TC: Creator,
-    E: VerificationExecutor<TC::TaskData, VerificationData>,
+    E: VerificationExecutor<TC::TaskData, VD>,
     V: ValidatorTrait,
     C: Clock,
+    VD: FromBlsAggregation + Send + Sync,
 {
     /// Creates a new Orchestrator instance with the given dependencies.
     ///
@@ -110,17 +115,19 @@ where
             task_creator,
             executor,
             validator,
+            _verification_data: PhantomData,
         }
     }
 }
 
 #[async_trait::async_trait]
-impl<TC, E, V, C> OrchestratorTrait for Orchestrator<TC, E, V, C>
+impl<TC, E, V, C, VD> OrchestratorTrait for Orchestrator<TC, E, V, C, VD>
 where
     TC: Creator + Send + Sync,
-    E: VerificationExecutor<TC::TaskData, VerificationData> + Send + Sync,
+    E: VerificationExecutor<TC::TaskData, VD> + Send + Sync,
     V: ValidatorTrait + Send + Sync,
     C: Clock + Send + Sync,
+    VD: FromBlsAggregation + Send + Sync,
 {
     async fn run(
         mut self,
@@ -289,19 +296,12 @@ where
                             panic!("failed to verify aggregated signature");
                         }
 
-                        // Execute verification with the aggregated signature
-                        // Serialize BLS-specific types to bytes for generic VerificationData
-                        let serialized_signatures: Vec<Vec<u8>> = agg_signatures.iter().map(|s| s.to_vec()).collect();
-                        let serialized_public_keys: Vec<Vec<u8>> = participating.iter().map(|pk| pk.to_vec()).collect();
-
-                        // Serialize G1 public keys to context
-                        let mut context = Vec::new();
-                        for g1_pubkey in &participating_g1 {
-                            context.extend_from_slice(g1_pubkey);
-                        }
-
-                        let verification_data = VerificationData::new(serialized_signatures, serialized_public_keys)
-                            .with_context(context);
+                        // Build the executor's verification-data container from the aggregation output.
+                        let verification_data = VD::from_bls_aggregation(
+                            agg_signatures,
+                            participating,
+                            participating_g1,
+                        );
 
                         match self.executor.execute_verification(
                             &expected_digest,
@@ -347,12 +347,13 @@ where
     }
 }
 
-impl<TC, E, V, C> Orchestrator<TC, E, V, C>
+impl<TC, E, V, C, VD> Orchestrator<TC, E, V, C, VD>
 where
     TC: Creator,
-    E: VerificationExecutor<TC::TaskData, VerificationData>,
+    E: VerificationExecutor<TC::TaskData, VD>,
     V: ValidatorTrait,
     C: Clock,
+    VD: FromBlsAggregation + Send + Sync,
 {
     /// Get a reference to the task creator
     #[allow(dead_code)]


### PR DESCRIPTION
Implements #156 (both the short- and long-term proposals).

## What
- Add a `FromBlsAggregation` bridge trait so `Orchestrator` is generic over the verification-data container, defaulting to `VerificationData` (fully backward compatible).
- `BlsEigenlayerExecutor` gains a typed `VerificationExecutor<_, BlsVerificationData>` impl. A consumer opts into the zero-copy path via `OrchestratorBuilder::build_with::<_, _, _, BlsVerificationData>`, eliminating the serialize/deserialize round-trip at the in-process orchestrator→executor boundary.
- Short-term: `VerificationData`'s byte fields move from `Vec<Vec<u8>>` to `Vec<Bytes>` for cheap reference-counted clones on the default path.

## Compatibility
- Existing consumers and the crate's own tests compile unchanged: the default `VD = VerificationData` and `build(...)` preserve today's behavior.
- The typed path is opt-in, explicitly chosen by the consumer — the generic `VerificationExecutor<T, V>` abstraction stays live for non-BLS executors.

## Tests
- All existing orchestrator tests pass on the default bytes path.
- New `test_orchestrator_passes_typed_bls_data` drives the full loop with `VD = BlsVerificationData` and asserts the executor receives the typed aggregation output with one entry per participating signer.

## Follow-up (separate PR)
- gas-killer/service opts in: set `VD = BlsVerificationData` on the `GasKillerOrchestrator` alias and call `build_with`, then bump the crate's git-rev pin.
