### PR TITLE
Pass round number to `BlsSignatureVerificationHandler::handle_verification`

### DIFF
--- a/examples/counter/router/src/executor.rs
+++ b/examples/counter/router/src/executor.rs
@@ -28,6 +28,7 @@ impl BlsSignatureVerificationHandler for CounterHandler {
     type TaskData = CounterTaskData;
     async fn handle_verification(
         &mut self,
+        _round: u64,
         msg_hash: FixedBytes<32>,
         quorum_numbers: Bytes,
         current_block_number: u32,

--- a/router/src/executor/bls/executor.rs
+++ b/router/src/executor/bls/executor.rs
@@ -94,6 +94,7 @@ impl<H: BlsSignatureVerificationHandler> VerificationExecutor<H::TaskData, Verif
 {
     async fn execute_verification(
         &mut self,
+        round: u64,
         payload_hash: &[u8],
         verification_data: VerificationData,
         task_data: Option<&H::TaskData>,
@@ -152,7 +153,7 @@ impl<H: BlsSignatureVerificationHandler> VerificationExecutor<H::TaskData, Verif
         let bls_verification_data =
             BlsVerificationData::new(signatures, public_keys, g1_public_keys);
 
-        self.execute_bls_verification(payload_hash, bls_verification_data, task_data)
+        self.execute_bls_verification(round, payload_hash, bls_verification_data, task_data)
             .await
     }
 }
@@ -164,11 +165,12 @@ impl<H: BlsSignatureVerificationHandler> VerificationExecutor<H::TaskData, BlsVe
 {
     async fn execute_verification(
         &mut self,
+        round: u64,
         payload_hash: &[u8],
         verification_data: BlsVerificationData,
         task_data: Option<&H::TaskData>,
     ) -> Result<ExecutionResult> {
-        self.execute_bls_verification(payload_hash, verification_data, task_data)
+        self.execute_bls_verification(round, payload_hash, verification_data, task_data)
             .await
     }
 }
@@ -179,6 +181,7 @@ impl<H: BlsSignatureVerificationHandler> BlsExecutorTrait<H::TaskData>
 {
     async fn execute_bls_verification(
         &mut self,
+        round: u64,
         payload_hash: &[u8],
         verification_data: BlsVerificationData,
         task_data: Option<&H::TaskData>,
@@ -239,6 +242,7 @@ impl<H: BlsSignatureVerificationHandler> BlsExecutorTrait<H::TaskData>
         let result = self
             .contract_handler
             .handle_verification(
+                round,
                 msg_hash,
                 quorum_numbers,
                 current_block_number

--- a/router/src/executor/bls/tests/mod.rs
+++ b/router/src/executor/bls/tests/mod.rs
@@ -29,6 +29,7 @@ impl BlsSignatureVerificationHandler for MockVerificationHandler {
     type TaskData = ();
     async fn handle_verification(
         &mut self,
+        _round: u64,
         _msg_hash: FixedBytes<32>,
         _quorum_numbers: Bytes,
         _current_block_number: u32,
@@ -51,6 +52,7 @@ struct TestBlsSignatureVerificationHandler {
     should_succeed: bool,
     expected_result: ExecutionResult,
     call_count: u32,
+    last_round: Option<u64>,
 }
 
 impl TestBlsSignatureVerificationHandler {
@@ -59,6 +61,7 @@ impl TestBlsSignatureVerificationHandler {
             should_succeed,
             expected_result,
             call_count: 0,
+            last_round: None,
         }
     }
 }
@@ -68,6 +71,7 @@ impl BlsSignatureVerificationHandler for TestBlsSignatureVerificationHandler {
     type TaskData = ();
     async fn handle_verification(
         &mut self,
+        round: u64,
         _msg_hash: FixedBytes<32>,
         _quorum_numbers: Bytes,
         _current_block_number: u32,
@@ -75,6 +79,7 @@ impl BlsSignatureVerificationHandler for TestBlsSignatureVerificationHandler {
         _task_data: Option<&Self::TaskData>,
     ) -> Result<ExecutionResult> {
         self.call_count += 1;
+        self.last_round = Some(round);
 
         if self.should_succeed {
             Ok(self.expected_result.clone())
@@ -126,6 +131,7 @@ async fn test_mock_verification_handler_success() {
 
     let result = handler
         .handle_verification(
+            7,
             msg_hash,
             quorum_numbers,
             current_block_number,
@@ -180,6 +186,7 @@ async fn test_verification_handler_trait_success() {
 
     let result = handler
         .handle_verification(
+            42,
             msg_hash,
             quorum_numbers,
             current_block_number,
@@ -197,6 +204,11 @@ async fn test_verification_handler_trait_success() {
     assert_eq!(execution_result.block_number, expected_result.block_number);
     assert_eq!(execution_result.gas_used, expected_result.gas_used);
     assert_eq!(handler.call_count, 1);
+    assert_eq!(
+        handler.last_round,
+        Some(42),
+        "handler should receive the round number passed by the caller"
+    );
 }
 
 #[tokio::test]
@@ -236,6 +248,7 @@ async fn test_verification_handler_trait_failure() {
 
     let result = handler
         .handle_verification(
+            42,
             msg_hash,
             quorum_numbers,
             current_block_number,

--- a/router/src/executor/bls/traits.rs
+++ b/router/src/executor/bls/traits.rs
@@ -14,6 +14,7 @@ where
 {
     async fn execute_bls_verification(
         &mut self,
+        round: u64,
         payload_hash: &[u8],
         verification_data: BlsVerificationData,
         task_data: Option<&T>,
@@ -27,6 +28,7 @@ pub trait BlsSignatureVerificationHandler: Send + Sync {
 
     async fn handle_verification(
         &mut self,
+        round: u64,
         msg_hash: FixedBytes<32>,
         quorum_numbers: Bytes,
         current_block_number: u32,

--- a/router/src/executor/tests/mock.rs
+++ b/router/src/executor/tests/mock.rs
@@ -177,6 +177,7 @@ where
 {
     async fn execute_verification(
         &mut self,
+        _round: u64,
         _digest: &[u8],
         _verification_data: VerificationData,
         _task_data: Option<&T>,

--- a/router/src/executor/traits.rs
+++ b/router/src/executor/traits.rs
@@ -12,6 +12,7 @@ where
 {
     async fn execute_verification(
         &mut self,
+        round: u64,
         payload_hash: &[u8],
         verification_data: V,
         task_data: Option<&T>,

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -356,16 +356,20 @@ async fn test_executor_called_exactly_once_after_threshold() {
 struct RecordingBlsExecutor {
     /// (signatures, public_keys, g1_public_keys) counts from the last call.
     received: Arc<Mutex<Option<(usize, usize, usize)>>>,
+    /// Round number from the last call.
+    received_round: Arc<Mutex<Option<u64>>>,
 }
 
 #[async_trait]
 impl VerificationExecutor<TestTaskData, BlsVerificationData> for RecordingBlsExecutor {
     async fn execute_verification(
         &mut self,
+        round: u64,
         _payload_hash: &[u8],
         verification_data: BlsVerificationData,
         _task_data: Option<&TestTaskData>,
     ) -> anyhow::Result<ExecutionResult> {
+        *self.received_round.lock().unwrap() = Some(round);
         *self.received.lock().unwrap() = Some((
             verification_data.signatures.len(),
             verification_data.public_keys.len(),
@@ -405,8 +409,10 @@ async fn test_orchestrator_passes_typed_bls_data() {
         .with_aggregation_frequency(Duration::from_millis(100));
 
     let received = Arc::new(Mutex::new(None));
+    let received_round = Arc::new(Mutex::new(None));
     let executor = RecordingBlsExecutor {
         received: received.clone(),
+        received_round: received_round.clone(),
     };
     let validator = MockValidator::new_success(1);
 
@@ -456,6 +462,11 @@ async fn test_orchestrator_passes_typed_bls_data() {
         *received.lock().unwrap(),
         Some((2, 2, 2)),
         "orchestrator should deliver typed BlsVerificationData with one entry per signer"
+    );
+    assert_eq!(
+        *received_round.lock().unwrap(),
+        Some(1),
+        "orchestrator should pass the round number through to the executor"
     );
 
     drop(msg_tx);

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -304,6 +304,7 @@ where
                         );
 
                         match self.executor.execute_verification(
+                            msg.round,
                             &expected_digest,
                             verification_data,
                             Some(&msg.metadata),


### PR DESCRIPTION
Closes #154.

## Summary

`BlsSignatureVerificationHandler::handle_verification` had no way to know which orchestrator round triggered it, so handlers had to correlate execution back to a round through out-of-band state. With a single shared timestamp slot, a failed consensus round (where `handle_verification` never fires) leaks a stale timestamp into the next round's latency sample.

This threads a `round: u64` from the orchestrator down to the handler so implementations can key per-round bookkeeping (e.g. a `HashMap<u64, Instant>` for latency histograms) and safely drop stale entries from failed rounds.

## Changes

`round` originates as `msg.round` in the orchestrator and there is no shared state to read it from otherwise, so it is added to three trait methods and passed straight through:

- `VerificationExecutor::execute_verification`
- `BlsExecutorTrait::execute_bls_verification`
- `BlsSignatureVerificationHandler::handle_verification` — the issue's target API

The orchestrator passes `msg.round` into `execute_verification`; the BLS executor forwards it to `execute_bls_verification` → `handle_verification`. All in-repo implementors (`CounterHandler`, mocks) are updated. The example `CounterHandler` accepts the parameter as `_round` since it has no metrics to key on — the production handler in the `service` repo is the real consumer.

This is a breaking change to all three traits; downstream implementors must add the parameter.

## Tests

- `test_orchestrator_passes_typed_bls_data` — asserts the orchestrator threads `round == 1` end-to-end through the executor.
- `test_verification_handler_trait_success` — asserts the handler receives the round number it was called with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
