### PR TITLE
fix: return an error instead of panicking when AVS_DEPLOYMENT_PATH is unset

### DIFF
--- a/eigenlayer/src/config.rs
+++ b/eigenlayer/src/config.rs
@@ -23,7 +23,7 @@ pub struct ContractAddresses {
 impl AvsDeployment {
     pub fn load() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let deployment_path =
-            env::var("AVS_DEPLOYMENT_PATH").expect("AVS_DEPLOYMENT_PATH must be set");
+            env::var("AVS_DEPLOYMENT_PATH").map_err(|_| "AVS_DEPLOYMENT_PATH must be set")?;
         let content = fs::read_to_string(deployment_path)?;
         let deployment: AvsDeployment = serde_json::from_str(&content)?;
         Ok(deployment)


### PR DESCRIPTION
`AvsDeployment::load()` was the one spot in the config-loading path that could panic — a missing `AVS_DEPLOYMENT_PATH` hit `.expect(...)`. Replace it with graceful error propagation (`.map_err(...)?`) so the function returns `Err` like the rest of `load()`, matching the library convention of not panicking on recoverable errors.

Closes #132.
