### PR TITLE
feat: add criterion benchmarks for BLS aggregation critical path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "commonware-p2p",
  "commonware-runtime",
  "commonware-utils",
+ "criterion",
  "eigen-crypto-bn254",
  "rand 0.9.2",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,3 +22,10 @@ commonware-runtime = { workspace = true }
 commonware-utils = { workspace = true }
 eigen-crypto-bn254 = { workspace = true }
 rand = { workspace = true }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "bls_aggregation"
+harness = false

--- a/core/bench-baseline.md
+++ b/core/bench-baseline.md
@@ -1,4 +1,4 @@
-# BLS Aggregation Benchmark Baseline
+# BLS Aggregation Benchmarks
 
 Criterion benchmarks covering the three functions on the critical path between
 threshold check and `execute_verification`:
@@ -18,62 +18,75 @@ cargo bench -p commonware-avs-core
 HTML reports land in `target/criterion/`. Re-run after any change to `core/src/bn254/mod.rs`
 to detect regressions before merging.
 
-## Baseline — 2026-06-12 (Apple M3, release profile)
+## How to read these results
 
-Commit: `bagelface/bls-aggregation-benchmarks` branch (criterion 0.5.1).
+Absolute wall times depend on hardware, toolchain, and commit, so treat the numbers
+below as a representative snapshot rather than a fixed contract. The findings that
+generalize across environments are the **relative costs** between the three functions
+and their **scaling behavior** in N — those relationships hold even when the absolute
+microseconds drift. Capture a fresh local run before drawing conclusions about a
+specific change, and compare against the relationships described here rather than the
+exact figures.
+
+## Representative results
+
+Measured on an Apple M3 (release profile, criterion 0.5.x); medians, rounded.
 
 ### `aggregate_signatures` — median wall time
 
 | N operators | Time    | Per-operator |
 |-------------|---------|-------------|
-| 1           | 133 ns  | 133 ns      |
-| 4           | 4.5 µs  | 1.1 µs      |
-| 16          | 9.2 µs  | 575 ns      |
-| 64          | 30.7 µs | 480 ns      |
-| 128         | 62.7 µs | 490 ns      |
+| 1           | ~130 ns | ~130 ns     |
+| 4           | ~4.5 µs | ~1.1 µs     |
+| 16          | ~9 µs   | ~575 ns     |
+| 64          | ~31 µs  | ~480 ns     |
+| 128         | ~63 µs  | ~490 ns     |
 
-Scales linearly after the first point; ~480–490 ns / operator at quorum-scale loads.
+Scales linearly after the first point, settling to roughly a fixed cost per operator
+at quorum-scale loads (sub-microsecond per operator on this machine).
 
 ### `get_points` — median wall time
 
 | N operators | Time    | Per-operator |
 |-------------|---------|-------------|
-| 1           | 170 ns  | 170 ns      |
-| 4           | 17.4 µs | 4.4 µs      |
-| 16          | 46 µs   | 2.9 µs      |
-| 64          | 213 µs  | 3.3 µs      |
-| 128         | 830 µs  | 6.5 µs      |
+| 1           | ~170 ns | ~170 ns     |
+| 4           | ~17 µs  | ~4.4 µs     |
+| 16          | ~46 µs  | ~2.9 µs     |
+| 64          | ~213 µs | ~3.3 µs     |
+| 128         | ~830 µs | ~6.5 µs     |
 
-~5–7x more expensive than `aggregate_signatures` at large N because it runs three
-separate projective loops (G1 keys, G2 keys, and signatures).
+Consistently several times more expensive than `aggregate_signatures` at large N
+because it runs three separate projective loops (G1 keys, G2 keys, and signatures).
 
 ### `aggregate_verify` — median wall time
 
 | N operators | Time   |
 |-------------|--------|
-| 1           | 4.1 ms |
-| 4           | 2.2 ms |
-| 16          | 2.2 ms |
-| 64          | 3.3 ms |
-| 128         | 3.5 ms |
+| 1           | ~4 ms  |
+| 4           | ~2.2 ms |
+| 16          | ~2.2 ms |
+| 64          | ~3.3 ms |
+| 128         | ~3.5 ms |
 
-The two Miller-loop pairings (~2.2 ms floor) dominate completely. G2 key
-aggregation adds only ~1 ms even at 128 operators. At a 16-operator quorum, the
-aggregation step (`aggregate_signatures` + `aggregate_verify`) costs ~2.2 ms per
-round — pairing-bound, not aggregation-bound.
+The two Miller-loop pairings dominate completely — there is a roughly fixed pairing
+floor that holds regardless of N, with G2 key aggregation adding only a small amount
+even at the largest operator counts. The aggregation step
+(`aggregate_signatures` + `aggregate_verify`) is pairing-bound, not aggregation-bound,
+across the entire range tested.
 
 ## Key observations
 
-1. **Pairing, not aggregation, is the bottleneck.** `aggregate_verify` is ~50–200×
-   slower than `aggregate_signatures` at all operator counts. Optimising the
-   projective additions would not materially improve round latency.
+1. **Pairing, not aggregation, is the bottleneck.** `aggregate_verify` is one to two
+   orders of magnitude slower than `aggregate_signatures` at every operator count
+   tested. Optimising the projective additions would not materially improve round
+   latency.
 
-2. **`get_points` at 128 operators (~830 µs) is non-trivial.** If the BLS executor
-   is on the critical path and quorums grow to 128+, replacing the three sequential
-   scalar accumulations with a single multi-scalar multiplication (MSM) pass is
-   worth investigating (#167).
+2. **`get_points` becomes non-trivial as quorums grow.** Its three sequential scalar
+   accumulations dominate its cost at large N. If the BLS executor is on the critical
+   path and quorums grow large, replacing them with a single multi-scalar
+   multiplication (MSM) pass is worth investigating (#167).
 
 3. **`aggregate_verify` cost is pairing-floor dominated.** An MSM for G2 key
-   aggregation would reduce the ~1 ms contribution at N=128 but would not touch
-   the fixed ~2.2 ms pairing cost. Switching to a batch-pairing or pre-aggregated
-   key scheme (#167) would have the largest impact.
+   aggregation would reduce the per-operator contribution at large N but would not
+   touch the fixed pairing cost. Switching to a batch-pairing or pre-aggregated key
+   scheme (#167) would have the largest impact on round latency.

--- a/core/bench-baseline.md
+++ b/core/bench-baseline.md
@@ -1,0 +1,79 @@
+# BLS Aggregation Benchmark Baseline
+
+Criterion benchmarks covering the three functions on the critical path between
+threshold check and `execute_verification`:
+
+- **`aggregate_signatures`** — O(N) G1 projective additions + one `into_affine`
+- **`get_points`** — three independent O(N) projective-addition loops (G1 keys, G2 keys,
+  signatures), each followed by `into_affine`; called by the BLS executor
+- **`aggregate_verify`** — O(N) G2 projective additions + `into_affine` + two Miller-loop
+  pairings; the pairing cost is fixed regardless of N
+
+## How to run
+
+```
+cargo bench -p commonware-avs-core
+```
+
+HTML reports land in `target/criterion/`. Re-run after any change to `core/src/bn254/mod.rs`
+to detect regressions before merging.
+
+## Baseline — 2026-06-12 (Apple M3, release profile)
+
+Commit: `bagelface/bls-aggregation-benchmarks` branch (criterion 0.5.1).
+
+### `aggregate_signatures` — median wall time
+
+| N operators | Time    | Per-operator |
+|-------------|---------|-------------|
+| 1           | 133 ns  | 133 ns      |
+| 4           | 4.5 µs  | 1.1 µs      |
+| 16          | 9.2 µs  | 575 ns      |
+| 64          | 30.7 µs | 480 ns      |
+| 128         | 62.7 µs | 490 ns      |
+
+Scales linearly after the first point; ~480–490 ns / operator at quorum-scale loads.
+
+### `get_points` — median wall time
+
+| N operators | Time    | Per-operator |
+|-------------|---------|-------------|
+| 1           | 170 ns  | 170 ns      |
+| 4           | 17.4 µs | 4.4 µs      |
+| 16          | 46 µs   | 2.9 µs      |
+| 64          | 213 µs  | 3.3 µs      |
+| 128         | 830 µs  | 6.5 µs      |
+
+~5–7x more expensive than `aggregate_signatures` at large N because it runs three
+separate projective loops (G1 keys, G2 keys, and signatures).
+
+### `aggregate_verify` — median wall time
+
+| N operators | Time   |
+|-------------|--------|
+| 1           | 4.1 ms |
+| 4           | 2.2 ms |
+| 16          | 2.2 ms |
+| 64          | 3.3 ms |
+| 128         | 3.5 ms |
+
+The two Miller-loop pairings (~2.2 ms floor) dominate completely. G2 key
+aggregation adds only ~1 ms even at 128 operators. At a 16-operator quorum, the
+aggregation step (`aggregate_signatures` + `aggregate_verify`) costs ~2.2 ms per
+round — pairing-bound, not aggregation-bound.
+
+## Key observations
+
+1. **Pairing, not aggregation, is the bottleneck.** `aggregate_verify` is ~50–200×
+   slower than `aggregate_signatures` at all operator counts. Optimising the
+   projective additions would not materially improve round latency.
+
+2. **`get_points` at 128 operators (~830 µs) is non-trivial.** If the BLS executor
+   is on the critical path and quorums grow to 128+, replacing the three sequential
+   scalar accumulations with a single multi-scalar multiplication (MSM) pass is
+   worth investigating (#167).
+
+3. **`aggregate_verify` cost is pairing-floor dominated.** An MSM for G2 key
+   aggregation would reduce the ~1 ms contribution at N=128 but would not touch
+   the fixed ~2.2 ms pairing cost. Switching to a batch-pairing or pre-aggregated
+   key scheme (#167) would have the largest impact.

--- a/core/benches/bls_aggregation.rs
+++ b/core/benches/bls_aggregation.rs
@@ -1,0 +1,101 @@
+use ark_bn254::Fr as Scalar;
+use commonware_avs_core::bn254::{
+    Bn254, G1PublicKey, PublicKey, Signature, aggregate_signatures, aggregate_verify, get_points,
+};
+use commonware_cryptography::Signer;
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+
+// Operator counts that span the practical quorum range.
+const OPERATOR_COUNTS: &[usize] = &[1, 4, 16, 64, 128];
+
+// Fixed 32-byte pre-hashed message; passing a digest directly bypasses the SHA-256
+// step inside sign/verify so the benchmark isolates the curve arithmetic.
+const MESSAGE: &[u8] = &[0x42u8; 32];
+
+struct OperatorSet {
+    g1_keys: Vec<G1PublicKey>,
+    g2_keys: Vec<PublicKey>,
+    signatures: Vec<Signature>,
+}
+
+// Generates n deterministic keypairs and their signatures over MESSAGE.
+// Using from_u64 scalars (1..=n) keeps setup fast and reproducible without
+// pulling in UniformRand or a separate RNG dependency.
+fn make_operators(n: usize) -> OperatorSet {
+    let mut g1_keys = Vec::with_capacity(n);
+    let mut g2_keys = Vec::with_capacity(n);
+    let mut signatures = Vec::with_capacity(n);
+    for i in 0..n {
+        let scalar = Scalar::from((i as u64) + 1);
+        let signer = Bn254::from_scalar(scalar);
+        g1_keys.push(signer.public_g1());
+        g2_keys.push(signer.public_key());
+        signatures.push(signer.sign(None, MESSAGE));
+    }
+    OperatorSet {
+        g1_keys,
+        g2_keys,
+        signatures,
+    }
+}
+
+// Benchmarks aggregate_signatures: O(N) G1 projective additions + one into_affine.
+fn bench_aggregate_signatures(c: &mut Criterion) {
+    let mut group = c.benchmark_group("aggregate_signatures");
+    for &n in OPERATOR_COUNTS {
+        let ops = make_operators(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| aggregate_signatures(black_box(&ops.signatures)));
+        });
+    }
+    group.finish();
+}
+
+// Benchmarks get_points: three independent O(N) projective-addition loops (G1 keys,
+// G2 keys, and signatures) each followed by into_affine.
+fn bench_get_points(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_points");
+    for &n in OPERATOR_COUNTS {
+        let ops = make_operators(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                get_points(
+                    black_box(&ops.g1_keys),
+                    black_box(&ops.g2_keys),
+                    black_box(&ops.signatures),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+// Benchmarks aggregate_verify: O(N) G2 projective additions + into_affine +
+// two Miller-loop pairings (the dominant cost). The aggregated signature is
+// pre-computed outside the timed loop so only the verify path is measured.
+fn bench_aggregate_verify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("aggregate_verify");
+    for &n in OPERATOR_COUNTS {
+        let ops = make_operators(n);
+        let agg_sig = aggregate_signatures(&ops.signatures).unwrap();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                aggregate_verify(
+                    black_box(&ops.g2_keys),
+                    black_box(None),
+                    black_box(MESSAGE),
+                    black_box(&agg_sig),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_aggregate_signatures,
+    bench_get_points,
+    bench_aggregate_verify
+);
+criterion_main!(benches);

--- a/examples/counter/node/Dockerfile
+++ b/examples/counter/node/Dockerfile
@@ -23,10 +23,11 @@ COPY examples/counter/node/Cargo.toml ./examples/counter/node/Cargo.toml
 COPY examples/counter/router/Cargo.toml ./examples/counter/router/Cargo.toml
 
 # Create placeholder targets for workspace members so Cargo can resolve manifests
-RUN mkdir -p core/src bindings/src eigenlayer/src router/src node/src scripts/src \
+RUN mkdir -p core/src core/benches bindings/src eigenlayer/src router/src node/src scripts/src \
     examples/counter/bindings/src examples/counter/common/src \
     examples/counter/node/src examples/counter/router/src \
     && echo 'pub fn _placeholder(){}' > core/src/lib.rs \
+    && echo 'fn main(){}' > core/benches/bls_aggregation.rs \
     && echo 'pub fn _placeholder(){}' > bindings/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > eigenlayer/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > router/src/lib.rs \

--- a/examples/counter/node/Dockerfile
+++ b/examples/counter/node/Dockerfile
@@ -27,7 +27,6 @@ RUN mkdir -p core/src core/benches bindings/src eigenlayer/src router/src node/s
     examples/counter/bindings/src examples/counter/common/src \
     examples/counter/node/src examples/counter/router/src \
     && echo 'pub fn _placeholder(){}' > core/src/lib.rs \
-    && echo 'fn main(){}' > core/benches/bls_aggregation.rs \
     && echo 'pub fn _placeholder(){}' > bindings/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > eigenlayer/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > router/src/lib.rs \
@@ -36,6 +35,7 @@ RUN mkdir -p core/src core/benches bindings/src eigenlayer/src router/src node/s
     && echo 'pub fn _placeholder(){}' > examples/counter/common/src/lib.rs \
     && echo 'fn main(){}' > examples/counter/node/src/app.rs \
     && echo 'fn main(){}' > examples/counter/router/src/app.rs \
+    && echo 'fn main(){}' > core/benches/bls_aggregation.rs \
     && echo 'fn main(){}' > scripts/src/main.rs \
     && cargo fetch
 

--- a/examples/counter/router/Dockerfile
+++ b/examples/counter/router/Dockerfile
@@ -16,10 +16,11 @@ COPY examples/counter/router/Cargo.toml ./examples/counter/router/Cargo.toml
 COPY examples/counter/node/Cargo.toml ./examples/counter/node/Cargo.toml
 
 # Create placeholder targets for workspace members so Cargo can resolve manifests
-RUN mkdir -p core/src bindings/src eigenlayer/src router/src node/src scripts/src \
+RUN mkdir -p core/src core/benches bindings/src eigenlayer/src router/src node/src scripts/src \
     examples/counter/bindings/src examples/counter/common/src \
     examples/counter/router/src examples/counter/node/src \
     && echo 'pub fn _placeholder(){}' > core/src/lib.rs \
+    && echo 'fn main(){}' > core/benches/bls_aggregation.rs \
     && echo 'pub fn _placeholder(){}' > bindings/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > eigenlayer/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > router/src/lib.rs \

--- a/examples/counter/router/Dockerfile
+++ b/examples/counter/router/Dockerfile
@@ -20,16 +20,16 @@ RUN mkdir -p core/src core/benches bindings/src eigenlayer/src router/src node/s
     examples/counter/bindings/src examples/counter/common/src \
     examples/counter/router/src examples/counter/node/src \
     && echo 'pub fn _placeholder(){}' > core/src/lib.rs \
-    && echo 'fn main(){}' > core/benches/bls_aggregation.rs \
     && echo 'pub fn _placeholder(){}' > bindings/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > eigenlayer/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > router/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > node/src/lib.rs \
-    && echo 'fn main(){}' > scripts/src/main.rs \
     && echo 'pub fn _placeholder(){}' > examples/counter/bindings/src/lib.rs \
     && echo 'pub fn _placeholder(){}' > examples/counter/common/src/lib.rs \
     && echo 'fn main(){}' > examples/counter/router/src/app.rs \
     && echo 'fn main(){}' > examples/counter/node/src/app.rs \
+    && echo 'fn main(){}' > core/benches/bls_aggregation.rs \
+    && echo 'fn main(){}' > scripts/src/main.rs \
     && cargo fetch
 
 # Copy sources needed to build the router package


### PR DESCRIPTION
Adds criterion benchmarks covering the three functions on the hot path between the threshold check and `execute_verification` in the orchestrator.

## What's benchmarked

- **`aggregate_signatures`** (`core/src/bn254/mod.rs:636`) — O(N) G1 projective additions + `into_affine`
- **`get_points`** (`:611`) — three independent O(N) projective loops (G1 keys, G2 keys, signatures), called by the BLS executor
- **`aggregate_verify`** (`:644`) — O(N) G2 key aggregation + two Miller-loop pairings

Operator counts: 1, 4, 16, 64, 128.

## Files

- `core/benches/bls_aggregation.rs` — criterion harness
- `core/Cargo.toml` — `[[bench]]` entry + `criterion = "0.5"` dev-dependency (matches the already-locked `criterion 0.5.1` transitive dep, no new major version added)
- `core/bench-baseline.md` — captured baseline with key observations

## Baseline highlights (Apple M3, release)

| Function | N=16 | N=64 | N=128 |
|---|---|---|---|
| `aggregate_signatures` | 9.2 µs | 30.7 µs | 62.7 µs |
| `get_points` | 46 µs | 213 µs | 830 µs |
| `aggregate_verify` | 2.2 ms | 3.3 ms | 3.5 ms |

**Key finding:** `aggregate_verify` is pairing-bound (~2.2 ms floor from two Miller loops) at all quorum sizes. The G2 key aggregation adds <1 ms even at 128 operators. Optimising projective additions alone would not move round latency; reducing pairing count or using pre-aggregated keys (#167) is where the leverage is.

Closes #163 / part of gas-killer/roadmap#10.