### PR TITLE
rename AGGREGATION_FREQUENCY env var to AGGREGATION_TIMEOUT

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -198,7 +198,6 @@ jobs:
           fi
 
       - name: Test with fast aggregation timeout
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         run: |
           echo "Testing with fast aggregation timeout (0.5 seconds)..."
 
@@ -252,7 +251,6 @@ jobs:
           fi
 
       - name: Test with ingress enabled
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         run: |
           echo "Testing with ingress enabled..."
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -197,13 +197,13 @@ jobs:
             exit 1
           fi
 
-      - name: Test with fast aggregation frequency
+      - name: Test with fast aggregation timeout
         if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         run: |
-          echo "Testing with fast aggregation frequency (0.5 seconds)..."
+          echo "Testing with fast aggregation timeout (0.5 seconds)..."
 
-          # Update the .env file to set fast aggregation
-          echo "AGGREGATION_FREQUENCY=0.5" >> .env
+          # Update the .env file to set fast aggregation timeout
+          echo "AGGREGATION_TIMEOUT=0.5" >> .env
 
           # Recreate only the router container to pick up new environment variables
           # Note: We stop and remove the router, then recreate it with --no-deps

--- a/example.env
+++ b/example.env
@@ -94,6 +94,6 @@ SIGNER_ENDPOINT=http://signer:50051
 # =============================================================================
 INGRESS=false
 
-# Aggregation frequency in seconds (supports fractional values)
+# Aggregation timeout in seconds (supports fractional values)
 # Examples: 30 (default), 1, 0.5, 0.3, 0.1
-# AGGREGATION_FREQUENCY=30
+# AGGREGATION_TIMEOUT=30

--- a/router/README.md
+++ b/router/README.md
@@ -37,7 +37,7 @@ Required environment variables:
 - `PRIVATE_KEY`: Private key for transactions. **NOTE:** Address must be funded on Sepolia testnet
 
 Optional environment variables:
-- `AGGREGATION_FREQUENCY`: Signature aggregation frequency in seconds, supports fractional values (default: 30)
+- `AGGREGATION_TIMEOUT`: Aggregation timeout in seconds — max wait per round before declaring it stalled, supports fractional values (default: 30)
   - Examples: `30` (30 seconds), `1` (1 second), `0.1` (100ms), `0.5` (500ms)
 - `THRESHOLD`: Minimum signatures required for aggregation
 - `INGRESS`: Enable HTTP ingress mode (true/false)
@@ -67,7 +67,7 @@ services:
       - WS_RPC=${WS_RPC}
       - AVS_DEPLOYMENT_PATH=/app/config/avs_deploy.json
       - PRIVATE_KEY=${PRIVATE_KEY}
-      - AGGREGATION_FREQUENCY=${AGGREGATION_FREQUENCY:-30}
+      - AGGREGATION_TIMEOUT=${AGGREGATION_TIMEOUT:-30}
       - CONTRIBUTOR_1_KEYFILE=/app/keys/contributor1.bls.key.json
       - CONTRIBUTOR_2_KEYFILE=/app/keys/contributor2.bls.key.json
       - CONTRIBUTOR_3_KEYFILE=/app/keys/contributor3.bls.key.json

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -28,8 +28,8 @@ pub struct OrchestratorBuilderConfig<C: Clock + Metrics> {
 /// to construct an orchestrator instance.
 #[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    /// The aggregation frequency (how often to create new rounds)
-    pub aggregation_frequency: Duration,
+    /// Max duration to wait for operator signatures before abandoning a round
+    pub aggregation_timeout: Duration,
     /// The threshold number of signatures required for aggregation
     pub threshold: usize,
     /// Whether to use ingress mode (HTTP server for external requests)
@@ -41,7 +41,7 @@ pub struct OrchestratorConfig {
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
-            aggregation_frequency: Duration::from_secs(30),
+            aggregation_timeout: Duration::from_secs(30),
             threshold: 3,
             use_ingress: false,
             ingress_address: "0.0.0.0:8080".to_string(),
@@ -106,16 +106,16 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         self
     }
 
-    /// Sets the aggregation frequency.
+    /// Sets the aggregation timeout.
     ///
     /// # Arguments
-    /// * `frequency` - The frequency at which to create new rounds
+    /// * `timeout` - Max duration to wait for operator signatures before abandoning a round
     ///
     /// # Returns
     /// * `Self` - The builder for method chaining
     #[allow(dead_code)]
-    pub fn with_aggregation_frequency(mut self, frequency: Duration) -> Self {
-        self.config.aggregation_frequency = frequency;
+    pub fn with_aggregation_timeout(mut self, timeout: Duration) -> Self {
+        self.config.aggregation_timeout = timeout;
         self
     }
 
@@ -173,7 +173,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         if let Ok(freq) = std::env::var("AGGREGATION_TIMEOUT")
             && let Ok(seconds) = freq.parse::<f64>()
         {
-            self.config.aggregation_frequency = Duration::from_secs_f64(seconds);
+            self.config.aggregation_timeout = Duration::from_secs_f64(seconds);
             info!(
                 "Aggregation timeout set to {} seconds from environment",
                 seconds
@@ -223,7 +223,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            aggregation_frequency = ?self.config.aggregation_frequency,
+            aggregation_timeout = ?self.config.aggregation_timeout,
             use_ingress = self.config.use_ingress,
             "Validated orchestrator configuration"
         );
@@ -287,12 +287,12 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            aggregation_frequency = ?self.config.aggregation_frequency,
+            aggregation_timeout = ?self.config.aggregation_timeout,
             "Building generic orchestrator"
         );
 
         let config = crate::orchestrator::types::OrchestratorConfig {
-            aggregation_frequency: self.config.aggregation_frequency,
+            aggregation_timeout: self.config.aggregation_timeout,
             contributors: self.contributors,
             g1_map: self.g1_map,
             threshold: self.config.threshold,

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -170,8 +170,8 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         }
 
         // Check for aggregation timeout (supports fractional seconds)
-        if let Ok(freq) = std::env::var("AGGREGATION_TIMEOUT")
-            && let Ok(seconds) = freq.parse::<f64>()
+        if let Ok(timeout) = std::env::var("AGGREGATION_TIMEOUT")
+            && let Ok(seconds) = timeout.parse::<f64>()
         {
             self.config.aggregation_timeout = Duration::from_secs_f64(seconds);
             info!(

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -150,7 +150,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
     /// This method reads configuration from environment variables:
     /// - `INGRESS`: If set to "true", enables ingress mode
     /// - `INGRESS_ADDRESS`: The HTTP server address (defaults to "0.0.0.0:8080")
-    /// - `AGGREGATION_FREQUENCY`: The aggregation frequency in seconds (defaults to 30)
+    /// - `AGGREGATION_TIMEOUT`: The aggregation timeout in seconds (defaults to 30)
     /// - `THRESHOLD`: The signature threshold (defaults to 3)
     ///
     /// # Returns
@@ -169,13 +169,13 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
             self.config.ingress_address = address;
         }
 
-        // Check for aggregation frequency (supports fractional seconds)
-        if let Ok(freq) = std::env::var("AGGREGATION_FREQUENCY")
+        // Check for aggregation timeout (supports fractional seconds)
+        if let Ok(freq) = std::env::var("AGGREGATION_TIMEOUT")
             && let Ok(seconds) = freq.parse::<f64>()
         {
             self.config.aggregation_frequency = Duration::from_secs_f64(seconds);
             info!(
-                "Aggregation frequency set to {} seconds from environment",
+                "Aggregation timeout set to {} seconds from environment",
                 seconds
             );
         }

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -117,7 +117,7 @@ async fn test_builder_load_from_env() {
     unsafe {
         std::env::set_var("INGRESS", "true");
         std::env::set_var("INGRESS_ADDRESS", "0.0.0.0:9090");
-        std::env::set_var("AGGREGATION_FREQUENCY", "45");
+        std::env::set_var("AGGREGATION_TIMEOUT", "45");
         std::env::set_var("THRESHOLD", "7");
     }
 
@@ -136,7 +136,7 @@ async fn test_builder_load_from_env() {
     unsafe {
         std::env::remove_var("INGRESS");
         std::env::remove_var("INGRESS_ADDRESS");
-        std::env::remove_var("AGGREGATION_FREQUENCY");
+        std::env::remove_var("AGGREGATION_TIMEOUT");
         std::env::remove_var("THRESHOLD");
     }
 }

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -79,15 +79,15 @@ async fn test_builder_with_aggregation_timeout() {
     let clock = MockClock::new();
     let signer = signer::create_test_signer();
     let (contributors, g1_map) = contributor::create_test_contributors();
-    let frequency = Duration::from_secs(60);
+    let timeout = Duration::from_secs(60);
 
     let builder = OrchestratorBuilder::new(clock.clone(), signer)
         .with_contributors(contributors)
         .with_g1_map(g1_map)
-        .with_aggregation_timeout(frequency);
+        .with_aggregation_timeout(timeout);
 
     let config = builder.get_config().expect("Failed to get config");
-    assert_eq!(config.config.aggregation_timeout, frequency);
+    assert_eq!(config.config.aggregation_timeout, timeout);
 }
 
 #[tokio::test]

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -25,7 +25,7 @@ async fn test_builder_new() {
     let config = builder.get_config().expect("Failed to get config");
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
-    assert_eq!(config.config.aggregation_frequency, Duration::from_secs(30));
+    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(30));
     assert_eq!(config.config.threshold, 3);
 }
 
@@ -75,7 +75,7 @@ async fn test_builder_with_threshold() {
 }
 
 #[tokio::test]
-async fn test_builder_with_aggregation_frequency() {
+async fn test_builder_with_aggregation_timeout() {
     let clock = MockClock::new();
     let signer = signer::create_test_signer();
     let (contributors, g1_map) = contributor::create_test_contributors();
@@ -84,10 +84,10 @@ async fn test_builder_with_aggregation_frequency() {
     let builder = OrchestratorBuilder::new(clock.clone(), signer)
         .with_contributors(contributors)
         .with_g1_map(g1_map)
-        .with_aggregation_frequency(frequency);
+        .with_aggregation_timeout(frequency);
 
     let config = builder.get_config().expect("Failed to get config");
-    assert_eq!(config.config.aggregation_frequency, frequency);
+    assert_eq!(config.config.aggregation_timeout, frequency);
 }
 
 #[tokio::test]
@@ -129,7 +129,7 @@ async fn test_builder_load_from_env() {
     let config = builder.get_config().expect("Failed to get config");
     assert!(config.config.use_ingress);
     assert_eq!(config.config.ingress_address, "0.0.0.0:9090");
-    assert_eq!(config.config.aggregation_frequency, Duration::from_secs(45));
+    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(45));
     assert_eq!(config.config.threshold, 7);
 
     // Clean up environment variables
@@ -193,14 +193,14 @@ async fn test_builder_get_config() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(5)
-        .with_aggregation_frequency(Duration::from_secs(60));
+        .with_aggregation_timeout(Duration::from_secs(60));
 
     let config = builder.get_config().expect("Failed to get config");
 
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
     assert_eq!(config.config.threshold, 5);
-    assert_eq!(config.config.aggregation_frequency, Duration::from_secs(60));
+    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(60));
 }
 
 #[tokio::test]

--- a/router/src/orchestrator/tests/generic.rs
+++ b/router/src/orchestrator/tests/generic.rs
@@ -16,7 +16,7 @@ async fn test_orchestrator_new() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_frequency: Duration::from_secs(30),
+        aggregation_timeout: Duration::from_secs(30),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 2,
@@ -61,7 +61,7 @@ async fn test_orchestrator_task_creator_metadata() {
     };
 
     let config = OrchestratorConfig {
-        aggregation_frequency: Duration::from_secs(30),
+        aggregation_timeout: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -92,7 +92,7 @@ async fn test_orchestrator_executor_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_frequency: Duration::from_secs(30),
+        aggregation_timeout: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -123,7 +123,7 @@ async fn test_orchestrator_validator_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_frequency: Duration::from_secs(30),
+        aggregation_timeout: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -154,7 +154,7 @@ async fn test_orchestrator_config_creation() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_frequency: Duration::from_secs(45),
+        aggregation_timeout: Duration::from_secs(45),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3,
@@ -194,7 +194,7 @@ async fn test_orchestrator_threshold_validation() {
 
     // Test with threshold equal to number of contributors
     let config = OrchestratorConfig {
-        aggregation_frequency: Duration::from_secs(30),
+        aggregation_timeout: Duration::from_secs(30),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3, // Equal to number of contributors
@@ -230,7 +230,7 @@ async fn test_orchestrator_component_interaction() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_frequency: Duration::from_secs(30),
+        aggregation_timeout: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -25,7 +25,7 @@ async fn test_orchestrator_builder_integration() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(2)
-        .with_aggregation_frequency(Duration::from_millis(100))
+        .with_aggregation_timeout(Duration::from_millis(100))
         .with_ingress("127.0.0.1:8080".to_string());
 
     let task_creator = MockCreator::<TestTaskData>::new();
@@ -125,7 +125,7 @@ async fn test_orchestrator_config_integration() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(3)
-        .with_aggregation_frequency(Duration::from_secs(60))
+        .with_aggregation_timeout(Duration::from_secs(60))
         .with_ingress("0.0.0.0:9090".to_string());
 
     let task_creator = MockCreator::<TestTaskData>::new();
@@ -295,7 +295,7 @@ async fn test_executor_called_exactly_once_after_threshold() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_frequency(Duration::from_millis(100));
+        .with_aggregation_timeout(Duration::from_millis(100));
 
     let executor = MockExecutor::new();
     let exec_count = executor.execution_count_handle();
@@ -406,7 +406,7 @@ async fn test_orchestrator_passes_typed_bls_data() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_frequency(Duration::from_millis(100));
+        .with_aggregation_timeout(Duration::from_millis(100));
 
     let received = Arc::new(Mutex::new(None));
     let received_round = Arc::new(Mutex::new(None));
@@ -499,7 +499,7 @@ async fn test_metrics_observed_on_quorum_path() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_frequency(Duration::from_millis(100));
+        .with_aggregation_timeout(Duration::from_millis(100));
 
     let orchestrator = builder
         .build(
@@ -574,7 +574,7 @@ async fn test_metrics_round_timeout_counted() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_frequency(Duration::from_millis(100));
+        .with_aggregation_timeout(Duration::from_millis(100));
 
     let orchestrator = builder
         .build(

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -191,7 +191,7 @@ async fn test_orchestrator_environment_integration() {
     unsafe {
         std::env::set_var("INGRESS", "true");
         std::env::set_var("INGRESS_ADDRESS", "127.0.0.1:7070");
-        std::env::set_var("AGGREGATION_FREQUENCY", "120");
+        std::env::set_var("AGGREGATION_TIMEOUT", "120");
         std::env::set_var("THRESHOLD", "2");
     }
 
@@ -221,7 +221,7 @@ async fn test_orchestrator_environment_integration() {
     unsafe {
         std::env::remove_var("INGRESS");
         std::env::remove_var("INGRESS_ADDRESS");
-        std::env::remove_var("AGGREGATION_FREQUENCY");
+        std::env::remove_var("AGGREGATION_TIMEOUT");
         std::env::remove_var("THRESHOLD");
     }
 }

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -28,7 +28,7 @@ use crate::orchestrator::traits::OrchestratorTrait;
 /// Configuration for the generic orchestrator
 #[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    pub aggregation_frequency: Duration,
+    pub aggregation_timeout: Duration,
     pub contributors: Vec<PublicKey>,
     pub g1_map: HashMap<PublicKey, G1PublicKey>,
     pub threshold: usize,
@@ -58,7 +58,7 @@ where
     runtime: C,
     #[allow(dead_code)]
     signer: Bn254,
-    aggregation_frequency: Duration,
+    aggregation_timeout: Duration,
     contributors: Vec<PublicKey>,
     g1_map: HashMap<PublicKey, G1PublicKey>, // g2 (PublicKey) -> g1 (PublicKey)
     ordered_contributors: HashMap<PublicKey, usize>,
@@ -121,7 +121,7 @@ where
         Self {
             runtime,
             signer,
-            aggregation_frequency: config.aggregation_frequency,
+            aggregation_timeout: config.aggregation_timeout,
             contributors,
             g1_map: config.g1_map,
             ordered_contributors,
@@ -207,7 +207,7 @@ where
             }
 
             // Listen for messages until the next broadcast
-            let continue_time = self.runtime.current() + self.aggregation_frequency;
+            let continue_time = self.runtime.current() + self.aggregation_timeout;
             loop {
                 select! {
                     _ = self.runtime.sleep_until(continue_time) => {
@@ -370,7 +370,7 @@ where
                                 executed_rounds.clear();
                                 executed_rounds.insert(msg.round);
                                 // Return to the outer loop immediately so the next queued task is
-                                // fetched without waiting out `aggregation_frequency`. If a chain-polling
+                                // fetched without waiting out `aggregation_timeout`. If a chain-polling
                                 // creator re-returns this same round, the `executed_rounds` branch at the
                                 // top of the outer loop avoids re-broadcasting Start (sleeping up to 2s
                                 // when idle while still draining the receiver to prevent buffer build-up).


### PR DESCRIPTION
## Summary

- Renames the `AGGREGATION_FREQUENCY` environment variable to `AGGREGATION_TIMEOUT` in `load_from_env()` — the new name better reflects the semantics (it is the max wait before declaring a round stalled, not a throttle cadence)
- Updates the corresponding test fixtures, `example.env`, and `router/README.md`

## Test plan

- [ ] All 43 `commonware-avs-router` tests pass with the renamed var
- [ ] Verify `AGGREGATION_TIMEOUT=60` is picked up by `load_from_env()` and sets the field correctly