### PR TITLE
feat: add wait_for_new_round to Creator trait and remove orchestrator polling

### DIFF
--- a/examples/counter/router/src/creator.rs
+++ b/examples/counter/router/src/creator.rs
@@ -33,6 +33,17 @@ impl Creator for CounterCreator {
         Ok((payload, round))
     }
 
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        loop {
+            let round = self.provider.get_current_round().await?;
+            if round > current {
+                let payload = self.provider.encode_round(round);
+                return Ok((payload, round));
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        }
+    }
+
     fn get_task_metadata(&self) -> Self::TaskData {
         CounterTaskData::default()
     }
@@ -94,6 +105,19 @@ impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningCounterCreator<Q
         Ok((payload, round))
     }
 
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        use tokio::time::{Duration, sleep};
+        loop {
+            let _task = self.wait_for_task().await?;
+            let round = self.provider.get_current_round().await?;
+            if round > current {
+                let payload = self.provider.encode_round(round);
+                return Ok((payload, round));
+            }
+            sleep(Duration::from_millis(self.config.polling_interval_ms)).await;
+        }
+    }
+
     fn get_task_metadata(&self) -> Self::TaskData {
         if let Ok(current_task) = self.current_task.lock()
             && let Some(ref task) = *current_task
@@ -137,6 +161,13 @@ impl Creator for CounterCreatorType {
         match self {
             CounterCreatorType::Basic(creator) => creator.get_payload_and_round().await,
             CounterCreatorType::Listening(creator) => creator.get_payload_and_round().await,
+        }
+    }
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        match self {
+            CounterCreatorType::Basic(creator) => creator.wait_for_new_round(current).await,
+            CounterCreatorType::Listening(creator) => creator.wait_for_new_round(current).await,
         }
     }
 

--- a/examples/counter/router/src/creator.rs
+++ b/examples/counter/router/src/creator.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
+use tokio::time::{Duration, sleep};
 use tracing::error;
 
 use crate::provider::CounterProvider;
@@ -40,7 +41,7 @@ impl Creator for CounterCreator {
                 let payload = self.provider.encode_round(round);
                 return Ok((payload, round));
             }
-            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            sleep(Duration::from_secs(2)).await;
         }
     }
 
@@ -67,7 +68,6 @@ impl<Q: TaskQueue + Send + Sync + 'static> ListeningCounterCreator<Q> {
     }
 
     async fn wait_for_task(&self) -> Result<TaskRequest> {
-        use tokio::time::{Duration, sleep};
         let mut attempts = 0;
         let max_attempts = self.config.timeout_ms / self.config.polling_interval_ms;
         loop {
@@ -106,7 +106,6 @@ impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningCounterCreator<Q
     }
 
     async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
-        use tokio::time::{Duration, sleep};
         loop {
             let _task = self.wait_for_task().await?;
             let round = self.provider.get_current_round().await?;

--- a/router/src/creator/tests/mock.rs
+++ b/router/src/creator/tests/mock.rs
@@ -169,6 +169,10 @@ where
         Ok((payload, round))
     }
 
+    async fn wait_for_new_round(&self, _current: u64) -> Result<(Vec<u8>, u64)> {
+        self.get_payload_and_round().await
+    }
+
     fn get_task_metadata(&self) -> Self::TaskData {
         self.metadata.clone()
     }
@@ -180,5 +184,41 @@ where
 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{Buf, BufMut};
+    use commonware_codec::{EncodeSize, Read, Write};
+
+    #[derive(Clone, Default)]
+    struct NoData;
+
+    impl Write for NoData {
+        fn write(&self, _buf: &mut impl BufMut) {}
+    }
+
+    impl Read for NoData {
+        type Cfg = ();
+        fn read_cfg(_buf: &mut impl Buf, _: &()) -> Result<Self, commonware_codec::Error> {
+            Ok(Self)
+        }
+    }
+
+    impl EncodeSize for NoData {
+        fn encode_size(&self) -> usize {
+            0
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_new_round_returns_strictly_greater_round() {
+        let creator = MockCreator::<NoData>::new();
+        let (_, round) = creator.get_payload_and_round().await.unwrap();
+        assert_eq!(round, 1);
+        let (_, new_round) = creator.wait_for_new_round(round).await.unwrap();
+        assert!(new_round > round);
     }
 }

--- a/router/src/creator/traits.rs
+++ b/router/src/creator/traits.rs
@@ -10,6 +10,12 @@ pub trait Creator: Send + Sync {
     /// Compute and return the payload bytes and associated round.
     async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)>;
 
+    /// Block until the round advances past `current`, then return the new payload and round.
+    ///
+    /// Implementations poll their underlying data source at an appropriate interval. The
+    /// returned round is guaranteed to be strictly greater than `current`.
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)>;
+
     /// Get task metadata as the creator's specific data type.
     ///
     /// These metadata fields are used in the wire protocol messages and are typically

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -5,14 +5,79 @@ use crate::executor::bls::BlsVerificationData;
 use crate::executor::{ExecutionResult, MockExecutor, VerificationExecutor};
 use crate::orchestrator::builder::OrchestratorBuilder;
 use crate::orchestrator::traits::OrchestratorTrait;
+use anyhow::Result;
 use async_trait::async_trait;
 use commonware_avs_core::validator::MockValidator;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::helpers::{contributor, signer};
 use super::mocks::clock::MockClock;
 use super::mocks::{MockReceiver, MockSender};
+
+/// Wraps a `MockCreator` and separately counts calls to `get_payload_and_round` vs
+/// `wait_for_new_round`. Used to assert that the orchestrator does not re-call
+/// `get_payload_and_round` after a successful execution (the double-consume bug).
+struct TrackingCreator {
+    inner: MockCreator<TestTaskData>,
+    get_count: Arc<AtomicUsize>,
+    wait_count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Creator for TrackingCreator {
+    type TaskData = TestTaskData;
+
+    async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)> {
+        self.get_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.get_payload_and_round().await
+    }
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        self.wait_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.wait_for_new_round(current).await
+    }
+
+    fn get_task_metadata(&self) -> TestTaskData {
+        self.inner.get_task_metadata()
+    }
+}
+
+/// Returns `Err` on the first call to `wait_for_new_round`, then delegates to the inner
+/// creator. Used to assert that the orchestrator handles the error gracefully (no panic)
+/// rather than unwrapping.
+struct ErrorOnceCreator {
+    inner: MockCreator<TestTaskData>,
+    first_wait: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl Creator for ErrorOnceCreator {
+    type TaskData = TestTaskData;
+
+    async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)> {
+        self.inner.get_payload_and_round().await
+    }
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        let is_first = {
+            let mut guard = self.first_wait.lock().unwrap();
+            let was = *guard;
+            *guard = false;
+            was
+        };
+        if is_first {
+            Err(anyhow::anyhow!("simulated queue timeout"))
+        } else {
+            self.inner.wait_for_new_round(current).await
+        }
+    }
+
+    fn get_task_metadata(&self) -> TestTaskData {
+        self.inner.get_task_metadata()
+    }
+}
 
 #[tokio::test]
 async fn test_orchestrator_builder_integration() {
@@ -617,6 +682,187 @@ async fn test_metrics_round_timeout_counted() {
             "expected `{expected}` in encoded metrics:\n{encoded}"
         );
     }
+
+    drop(msg_tx);
+    handle.abort();
+}
+
+/// After a successful execution the orchestrator must use the `(payload, round)` returned by
+/// `wait_for_new_round` directly for the next broadcast rather than discarding that result and
+/// calling `get_payload_and_round` a second time. Calling `get_payload_and_round` an extra
+/// time per executed round causes double-consumption of queue-backed creators:
+/// `ListeningCounterCreator` pops a task from the shared queue on every call, so the extra
+/// call silently discards the task that should drive the next round.
+#[tokio::test(start_paused = true)]
+async fn test_get_payload_not_recalled_after_execution() {
+    use alloy::primitives::U256;
+    use alloy::sol_types::SolValue;
+    use bytes::Bytes;
+    use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
+    use commonware_codec::{EncodeSize, Write};
+    use commonware_cryptography::{Hasher, Sha256, Signer};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map, contributor_signers) =
+        contributor::create_test_contributors_with_signers();
+
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let wait_count = Arc::new(AtomicUsize::new(0));
+
+    let creator = TrackingCreator {
+        inner: MockCreator::<TestTaskData>::new(),
+        get_count: get_count.clone(),
+        wait_count: wait_count.clone(),
+    };
+
+    // Long aggregation timeout so round 2 does not time out before we snapshot counts.
+    let builder = OrchestratorBuilder::new(clock, orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_aggregation_timeout(Duration::from_secs(10));
+
+    let executor = MockExecutor::new();
+    let validator = MockValidator::new_success(1);
+
+    let orchestrator = builder
+        .build(creator, executor, validator)
+        .expect("failed to build orchestrator");
+
+    // MockValidator::new_success(1) always returns Sha256(U256::from(1).abi_encode()).
+    let expected_digest = {
+        let payload = U256::from(1u64).abi_encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        hasher.finalize()
+    };
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+    for contributor_signer in contributor_signers.iter().take(2) {
+        let sig = contributor_signer.sign(None, expected_digest.as_ref());
+        let msg = Aggregation::<TestTaskData>::new(
+            1,
+            TestTaskData::default(),
+            Some(Payload::Signature(sig.to_vec())),
+        );
+        let mut buf = Vec::with_capacity(msg.encode_size());
+        msg.write(&mut buf);
+        msg_tx
+            .send((contributor_signer.public_key(), Bytes::from(buf)))
+            .unwrap();
+    }
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Advance 1 ms — enough to flush the pre-queued channel messages and let execution
+    // fire, but far less than the 10 s aggregation timeout so round 2 has not yet timed
+    // out and triggered another get_payload_and_round call.
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+
+    // get_payload_and_round must have been called exactly once (for round 1).
+    // wait_for_new_round must have been called exactly once (for the round 1 → 2 transition).
+    // If the orchestrator discards the wait_for_new_round result and re-fetches, get_count == 2.
+    assert_eq!(
+        get_count.load(Ordering::SeqCst),
+        1,
+        "get_payload_and_round must not be re-called after execution; \
+         the wait_for_new_round return value must drive the next round"
+    );
+    assert_eq!(
+        wait_count.load(Ordering::SeqCst),
+        1,
+        "wait_for_new_round must be called exactly once after execution"
+    );
+
+    drop(msg_tx);
+    handle.abort();
+}
+
+/// After `wait_for_new_round` returns `Err` the orchestrator must log the error and
+/// retry rather than calling `.unwrap()` and panicking. A panicking orchestrator process
+/// takes the whole service down; for a queue-backed creator an idle queue produces a
+/// timeout error on every inter-round wait, so the panic is not a rare edge case.
+#[tokio::test(start_paused = true)]
+async fn test_orchestrator_survives_wait_for_new_round_error() {
+    use alloy::primitives::U256;
+    use alloy::sol_types::SolValue;
+    use bytes::Bytes;
+    use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
+    use commonware_codec::{EncodeSize, Write};
+    use commonware_cryptography::{Hasher, Sha256, Signer};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map, contributor_signers) =
+        contributor::create_test_contributors_with_signers();
+
+    let creator = ErrorOnceCreator {
+        inner: MockCreator::<TestTaskData>::new(),
+        first_wait: Arc::new(Mutex::new(true)),
+    };
+
+    let builder = OrchestratorBuilder::new(clock, orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_aggregation_timeout(Duration::from_secs(10));
+
+    let executor = MockExecutor::new();
+    let validator = MockValidator::new_success(1);
+
+    let orchestrator = builder
+        .build(creator, executor, validator)
+        .expect("failed to build orchestrator");
+
+    let expected_digest = {
+        let payload = U256::from(1u64).abi_encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        hasher.finalize()
+    };
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+    for contributor_signer in contributor_signers.iter().take(2) {
+        let sig = contributor_signer.sign(None, expected_digest.as_ref());
+        let msg = Aggregation::<TestTaskData>::new(
+            1,
+            TestTaskData::default(),
+            Some(Payload::Signature(sig.to_vec())),
+        );
+        let mut buf = Vec::with_capacity(msg.encode_size());
+        msg.write(&mut buf);
+        msg_tx
+            .send((contributor_signer.public_key(), Bytes::from(buf)))
+            .unwrap();
+    }
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Let execution fire and the first wait_for_new_round (which returns Err) run.
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+
+    // The orchestrator must still be alive — not finished due to an unwrap panic.
+    // With the current .unwrap() the spawned task finishes immediately after the panic.
+    assert!(
+        !handle.is_finished(),
+        "orchestrator must not panic on wait_for_new_round error; \
+         it should log and retry instead of calling .unwrap()"
+    );
 
     drop(msg_tx);
     handle.abort();

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -150,9 +150,22 @@ where
         mut receiver: impl Receiver<PublicKey = PublicKey>,
     ) {
         let mut signatures: HashMap<u64, RoundState> = HashMap::new();
+        // Carries the (payload, round) returned by wait_for_new_round after a successful
+        // execution so the outer loop can use it directly without an extra get_payload_and_round
+        // call. None on the first iteration and after every aggregation timeout.
+        let mut cached_round: Option<(Vec<u8>, u64)> = None;
 
         loop {
-            let (payload, current_round) = self.task_creator.get_payload_and_round().await.unwrap();
+            let (payload, current_round) = match cached_round.take() {
+                Some(val) => val,
+                None => match self.task_creator.get_payload_and_round().await {
+                    Ok(val) => val,
+                    Err(e) => {
+                        tracing::error!("get_payload_and_round failed: {e}");
+                        continue;
+                    }
+                },
+            };
 
             // Create a new hasher for each iteration
             let mut hasher = Sha256::new();
@@ -195,6 +208,7 @@ where
 
             // Listen for messages until the next broadcast
             let continue_time = self.runtime.current() + self.aggregation_timeout;
+            let mut executed_round: Option<u64> = None;
             loop {
                 select! {
                     _ = self.runtime.sleep_until(continue_time) => {
@@ -343,9 +357,7 @@ where
                                 );
                                 self.metrics.round_executions.inc(Status::Success);
                                 signatures.remove(&msg.round);
-                                // Block until on-chain state advances to the next round so the outer
-                                // loop broadcasts a fresh round immediately on return.
-                                self.task_creator.wait_for_new_round(msg.round).await.unwrap();
+                                executed_round = Some(msg.round);
                                 break;
                             },
                             Err(e) => {
@@ -361,6 +373,37 @@ where
                         }
                     },
                 }
+            }
+
+            // After the inner loop exits: if execution succeeded, wait until the on-chain
+            // round advances before broadcasting again. The receiver is drained concurrently
+            // to prevent P2P buffer build-up during the inter-round wait. Transient errors
+            // from wait_for_new_round (e.g. a queue-backed creator timing out between tasks)
+            // are logged and retried rather than panicking.
+            if let Some(ex_round) = executed_round {
+                let mut wait_fut = std::pin::pin!(self.task_creator.wait_for_new_round(ex_round));
+                cached_round = Some(loop {
+                    tokio::select! {
+                        biased;
+                        result = &mut wait_fut => {
+                            match result {
+                                Ok(val) => break val,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        round = ex_round,
+                                        "wait_for_new_round error: {e}; retrying"
+                                    );
+                                    wait_fut.set(
+                                        self.task_creator.wait_for_new_round(ex_round)
+                                    );
+                                }
+                            }
+                        },
+                        received = receiver.recv() => {
+                            let _ = received;
+                        }
+                    }
+                });
             }
         }
     }

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -14,7 +14,7 @@ use commonware_runtime::telemetry::metrics::status::{CounterExt, Status};
 use commonware_runtime::{Clock, Metrics};
 use commonware_utils::hex;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     marker::PhantomData,
     time::{Duration, SystemTime},
 };
@@ -150,7 +150,6 @@ where
         mut receiver: impl Receiver<PublicKey = PublicKey>,
     ) {
         let mut signatures: HashMap<u64, RoundState> = HashMap::new();
-        let mut executed_rounds: HashSet<u64> = HashSet::new();
 
         loop {
             let (payload, current_round) = self.task_creator.get_payload_and_round().await.unwrap();
@@ -164,18 +163,6 @@ where
                 msg = hex(&payload),
                 "generated payload for state"
             );
-
-            // Skip broadcasting for already-executed rounds, but keep servicing the receiver
-            // so late signatures/messages for completed rounds do not build up in the buffer.
-            if executed_rounds.contains(&current_round) {
-                select! {
-                    _ = self.runtime.sleep(Duration::from_secs(2)) => {},
-                    received = receiver.recv() => {
-                        let _ = received;
-                    },
-                }
-                continue;
-            }
 
             // Broadcast payload
             let task_data = self.task_creator.get_task_metadata();
@@ -234,11 +221,6 @@ where
                             self.metrics.signatures.inc(Status::Invalid);
                             continue;
                         };
-                        if executed_rounds.contains(&msg.round) {
-                            info!("Ignoring signature for already-executed round: {} from contributor: {:?}", msg.round, contributor);
-                            self.metrics.signatures.inc(Status::Dropped);
-                            continue;
-                        }
                         let Some(round) = signatures.get_mut(&msg.round) else {
                             info!("Received signature for unknown round: {} from contributor: {:?}", msg.round, contributor);
                             self.metrics.signatures.inc(Status::Dropped);
@@ -360,20 +342,10 @@ where
                                     result
                                 );
                                 self.metrics.round_executions.inc(Status::Success);
-                                // Drop per-round signature state now that this round has finished.
                                 signatures.remove(&msg.round);
-                                // Mark round complete so additional signatures are ignored and the outer
-                                // loop does not re-broadcast Start while waiting for on-chain state to advance.
-                                //
-                                // Rounds advance monotonically, so only the latest executed round needs to
-                                // be retained to suppress duplicate processing without unbounded growth.
-                                executed_rounds.clear();
-                                executed_rounds.insert(msg.round);
-                                // Return to the outer loop immediately so the next queued task is
-                                // fetched without waiting out `aggregation_timeout`. If a chain-polling
-                                // creator re-returns this same round, the `executed_rounds` branch at the
-                                // top of the outer loop avoids re-broadcasting Start (sleeping up to 2s
-                                // when idle while still draining the receiver to prevent buffer build-up).
+                                // Block until on-chain state advances to the next round so the outer
+                                // loop broadcasts a fresh round immediately on return.
+                                self.task_creator.wait_for_new_round(msg.round).await.unwrap();
                                 break;
                             },
                             Err(e) => {

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -149,6 +149,10 @@ where
         mut sender: impl Sender,
         mut receiver: impl Receiver<PublicKey = PublicKey>,
     ) {
+        // Backoff between wait_for_new_round retries; bounds hot-spinning when a creator
+        // fails immediately (e.g. CounterCreator when the provider is temporarily down).
+        const WAIT_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+
         let mut signatures: HashMap<u64, RoundState> = HashMap::new();
         // Carries the (payload, round) returned by wait_for_new_round after a successful
         // execution so the outer loop can use it directly without an extra get_payload_and_round
@@ -393,6 +397,11 @@ where
                                         round = ex_round,
                                         "wait_for_new_round error: {e}; retrying"
                                     );
+                                    self.runtime
+                                        .sleep_until(
+                                            self.runtime.current() + WAIT_RETRY_BACKOFF,
+                                        )
+                                        .await;
                                     wait_fut.set(
                                         self.task_creator.wait_for_new_round(ex_round)
                                     );


### PR DESCRIPTION
## Summary

- Adds `wait_for_new_round(current: u64) -> Result<(Vec<u8>, u64)>` to the `Creator` trait, which blocks until the round advances past `current`
- Removes `executed_rounds: HashSet<u64>` from the orchestrator's run loop — the orchestrator now calls `wait_for_new_round` after a successful execution and is guaranteed to receive a fresh round before broadcasting again
- Removes the 2-second polling sleep and receiver-drain guard that were needed to suppress re-broadcast of already-executed rounds
- Implements `wait_for_new_round` for `CounterCreator` (polls provider at 2s intervals), `ListeningCounterCreator` (waits for next queued task then checks round), `CounterCreatorType` (dispatches to variant), and `MockCreator` (increments counter)

## Test plan

- [ ] `cargo fmt --all` — clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo test --all-targets --all-features` — all 44 tests pass, including new `test_wait_for_new_round_returns_strictly_greater_round`
- [ ] Existing orchestrator integration tests (`test_executor_called_exactly_once_after_threshold`, `test_metrics_observed_on_quorum_path`, `test_metrics_round_timeout_counted`) all continue to pass

Closes #153