### PR TITLE
feat: decouple round_timeout from rebroadcast_interval in orchestrator

### DIFF
--- a/example.env
+++ b/example.env
@@ -94,6 +94,9 @@ SIGNER_ENDPOINT=http://signer:50051
 # =============================================================================
 INGRESS=false
 
-# Aggregation timeout in seconds (supports fractional values)
-# Examples: 30 (default), 1, 0.5, 0.3, 0.1
-# AGGREGATION_TIMEOUT=30
+# Max seconds to wait for threshold signatures before abandoning a round (supports fractional)
+# ROUND_TIMEOUT=30
+
+# How often (in seconds) to re-send the Start broadcast for an in-flight round.
+# Set longer than ROUND_TIMEOUT to disable intra-round rebroadcasting entirely.
+# REBROADCAST_INTERVAL=30

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -132,7 +132,6 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         self
     }
 
-
     /// Sets the threshold for signature aggregation.
     ///
     /// # Arguments
@@ -187,7 +186,10 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
             && let Ok(seconds) = val.parse::<f64>()
         {
             self.config.round_timeout = Duration::from_secs_f64(seconds);
-            info!("round_timeout set to {} seconds from ROUND_TIMEOUT", seconds);
+            info!(
+                "round_timeout set to {} seconds from ROUND_TIMEOUT",
+                seconds
+            );
         }
 
         // REBROADCAST_INTERVAL overrides only the intra-round Start re-send cadence.

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -28,8 +28,13 @@ pub struct OrchestratorBuilderConfig<C: Clock + Metrics> {
 /// to construct an orchestrator instance.
 #[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    /// Max duration to wait for operator signatures before abandoning a round
-    pub aggregation_timeout: Duration,
+    /// Max duration to wait for operator signatures before abandoning a round.
+    pub round_timeout: Duration,
+    /// How often to re-send the `Start` broadcast for an in-flight round while waiting
+    /// for signatures. Independent from `round_timeout` so recovery can be fast without
+    /// amplifying `Start` broadcasts. When equal to `round_timeout`, no intra-round
+    /// rebroadcast fires (the round times out first under the biased select).
+    pub rebroadcast_interval: Duration,
     /// The threshold number of signatures required for aggregation
     pub threshold: usize,
     /// Whether to use ingress mode (HTTP server for external requests)
@@ -41,7 +46,8 @@ pub struct OrchestratorConfig {
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
-            aggregation_timeout: Duration::from_secs(30),
+            round_timeout: Duration::from_secs(30),
+            rebroadcast_interval: Duration::from_secs(30),
             threshold: 3,
             use_ingress: false,
             ingress_address: "0.0.0.0:8080".to_string(),
@@ -106,18 +112,26 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         self
     }
 
-    /// Sets the aggregation timeout.
+    /// Sets the round timeout.
     ///
-    /// # Arguments
-    /// * `timeout` - Max duration to wait for operator signatures before abandoning a round
-    ///
-    /// # Returns
-    /// * `Self` - The builder for method chaining
+    /// Max duration to wait for operator signatures before abandoning a round.
     #[allow(dead_code)]
-    pub fn with_aggregation_timeout(mut self, timeout: Duration) -> Self {
-        self.config.aggregation_timeout = timeout;
+    pub fn with_round_timeout(mut self, timeout: Duration) -> Self {
+        self.config.round_timeout = timeout;
         self
     }
+
+    /// Sets the rebroadcast interval.
+    ///
+    /// How often to re-send the `Start` broadcast for an in-flight round while waiting
+    /// for signatures. Setting this longer than `round_timeout` disables intra-round
+    /// rebroadcasting entirely.
+    #[allow(dead_code)]
+    pub fn with_rebroadcast_interval(mut self, interval: Duration) -> Self {
+        self.config.rebroadcast_interval = interval;
+        self
+    }
+
 
     /// Sets the threshold for signature aggregation.
     ///
@@ -169,13 +183,20 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
             self.config.ingress_address = address;
         }
 
-        // Check for aggregation timeout (supports fractional seconds)
-        if let Ok(timeout) = std::env::var("AGGREGATION_TIMEOUT")
-            && let Ok(seconds) = timeout.parse::<f64>()
+        if let Ok(val) = std::env::var("ROUND_TIMEOUT")
+            && let Ok(seconds) = val.parse::<f64>()
         {
-            self.config.aggregation_timeout = Duration::from_secs_f64(seconds);
+            self.config.round_timeout = Duration::from_secs_f64(seconds);
+            info!("round_timeout set to {} seconds from ROUND_TIMEOUT", seconds);
+        }
+
+        // REBROADCAST_INTERVAL overrides only the intra-round Start re-send cadence.
+        if let Ok(val) = std::env::var("REBROADCAST_INTERVAL")
+            && let Ok(seconds) = val.parse::<f64>()
+        {
+            self.config.rebroadcast_interval = Duration::from_secs_f64(seconds);
             info!(
-                "Aggregation timeout set to {} seconds from environment",
+                "rebroadcast_interval set to {} seconds from REBROADCAST_INTERVAL",
                 seconds
             );
         }
@@ -223,7 +244,8 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            aggregation_timeout = ?self.config.aggregation_timeout,
+            round_timeout = ?self.config.round_timeout,
+            rebroadcast_interval = ?self.config.rebroadcast_interval,
             use_ingress = self.config.use_ingress,
             "Validated orchestrator configuration"
         );
@@ -287,12 +309,14 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            aggregation_timeout = ?self.config.aggregation_timeout,
+            round_timeout = ?self.config.round_timeout,
+            rebroadcast_interval = ?self.config.rebroadcast_interval,
             "Building generic orchestrator"
         );
 
         let config = crate::orchestrator::types::OrchestratorConfig {
-            aggregation_timeout: self.config.aggregation_timeout,
+            round_timeout: self.config.round_timeout,
+            rebroadcast_interval: self.config.rebroadcast_interval,
             contributors: self.contributors,
             g1_map: self.g1_map,
             threshold: self.config.threshold,

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -25,7 +25,8 @@ async fn test_builder_new() {
     let config = builder.get_config().expect("Failed to get config");
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
-    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(30));
+    assert_eq!(config.config.round_timeout, Duration::from_secs(30));
+    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(30));
     assert_eq!(config.config.threshold, 3);
 }
 
@@ -74,20 +75,24 @@ async fn test_builder_with_threshold() {
     assert_eq!(config.config.threshold, 5);
 }
 
+
 #[tokio::test]
-async fn test_builder_with_aggregation_timeout() {
+async fn test_builder_with_round_timeout_and_rebroadcast_interval() {
     let clock = MockClock::new();
     let signer = signer::create_test_signer();
     let (contributors, g1_map) = contributor::create_test_contributors();
-    let timeout = Duration::from_secs(60);
+    let round_timeout = Duration::from_secs(60);
+    let rebroadcast_interval = Duration::from_secs(10);
 
     let builder = OrchestratorBuilder::new(clock.clone(), signer)
         .with_contributors(contributors)
         .with_g1_map(g1_map)
-        .with_aggregation_timeout(timeout);
+        .with_round_timeout(round_timeout)
+        .with_rebroadcast_interval(rebroadcast_interval);
 
     let config = builder.get_config().expect("Failed to get config");
-    assert_eq!(config.config.aggregation_timeout, timeout);
+    assert_eq!(config.config.round_timeout, round_timeout);
+    assert_eq!(config.config.rebroadcast_interval, rebroadcast_interval);
 }
 
 #[tokio::test]
@@ -117,7 +122,8 @@ async fn test_builder_load_from_env() {
     unsafe {
         std::env::set_var("INGRESS", "true");
         std::env::set_var("INGRESS_ADDRESS", "0.0.0.0:9090");
-        std::env::set_var("AGGREGATION_TIMEOUT", "45");
+        std::env::set_var("ROUND_TIMEOUT", "45");
+        std::env::set_var("REBROADCAST_INTERVAL", "5");
         std::env::set_var("THRESHOLD", "7");
     }
 
@@ -129,14 +135,16 @@ async fn test_builder_load_from_env() {
     let config = builder.get_config().expect("Failed to get config");
     assert!(config.config.use_ingress);
     assert_eq!(config.config.ingress_address, "0.0.0.0:9090");
-    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(45));
+    assert_eq!(config.config.round_timeout, Duration::from_secs(45));
+    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(5));
     assert_eq!(config.config.threshold, 7);
 
     // Clean up environment variables
     unsafe {
         std::env::remove_var("INGRESS");
         std::env::remove_var("INGRESS_ADDRESS");
-        std::env::remove_var("AGGREGATION_TIMEOUT");
+        std::env::remove_var("ROUND_TIMEOUT");
+        std::env::remove_var("REBROADCAST_INTERVAL");
         std::env::remove_var("THRESHOLD");
     }
 }
@@ -193,14 +201,16 @@ async fn test_builder_get_config() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(5)
-        .with_aggregation_timeout(Duration::from_secs(60));
+        .with_round_timeout(Duration::from_secs(60))
+        .with_rebroadcast_interval(Duration::from_secs(15));
 
     let config = builder.get_config().expect("Failed to get config");
 
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
     assert_eq!(config.config.threshold, 5);
-    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(60));
+    assert_eq!(config.config.round_timeout, Duration::from_secs(60));
+    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(15));
 }
 
 #[tokio::test]

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -75,7 +75,6 @@ async fn test_builder_with_threshold() {
     assert_eq!(config.config.threshold, 5);
 }
 
-
 #[tokio::test]
 async fn test_builder_with_round_timeout_and_rebroadcast_interval() {
     let clock = MockClock::new();

--- a/router/src/orchestrator/tests/generic.rs
+++ b/router/src/orchestrator/tests/generic.rs
@@ -16,7 +16,8 @@ async fn test_orchestrator_new() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 2,
@@ -61,7 +62,8 @@ async fn test_orchestrator_task_creator_metadata() {
     };
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -92,7 +94,8 @@ async fn test_orchestrator_executor_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -123,7 +126,8 @@ async fn test_orchestrator_validator_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -154,7 +158,8 @@ async fn test_orchestrator_config_creation() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(45),
+        round_timeout: Duration::from_secs(45),
+        rebroadcast_interval: Duration::from_secs(45),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3,
@@ -194,7 +199,8 @@ async fn test_orchestrator_threshold_validation() {
 
     // Test with threshold equal to number of contributors
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3, // Equal to number of contributors
@@ -230,7 +236,8 @@ async fn test_orchestrator_component_interaction() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -90,7 +90,7 @@ async fn test_orchestrator_builder_integration() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100))
+        .with_round_timeout(Duration::from_millis(100))
         .with_ingress("127.0.0.1:8080".to_string());
 
     let task_creator = MockCreator::<TestTaskData>::new();
@@ -190,7 +190,7 @@ async fn test_orchestrator_config_integration() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(3)
-        .with_aggregation_timeout(Duration::from_secs(60))
+        .with_round_timeout(Duration::from_secs(60))
         .with_ingress("0.0.0.0:9090".to_string());
 
     let task_creator = MockCreator::<TestTaskData>::new();
@@ -256,7 +256,7 @@ async fn test_orchestrator_environment_integration() {
     unsafe {
         std::env::set_var("INGRESS", "true");
         std::env::set_var("INGRESS_ADDRESS", "127.0.0.1:7070");
-        std::env::set_var("AGGREGATION_TIMEOUT", "120");
+        std::env::set_var("ROUND_TIMEOUT", "120");
         std::env::set_var("THRESHOLD", "2");
     }
 
@@ -286,7 +286,7 @@ async fn test_orchestrator_environment_integration() {
     unsafe {
         std::env::remove_var("INGRESS");
         std::env::remove_var("INGRESS_ADDRESS");
-        std::env::remove_var("AGGREGATION_TIMEOUT");
+        std::env::remove_var("ROUND_TIMEOUT");
         std::env::remove_var("THRESHOLD");
     }
 }
@@ -360,7 +360,7 @@ async fn test_executor_called_exactly_once_after_threshold() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let executor = MockExecutor::new();
     let exec_count = executor.execution_count_handle();
@@ -471,7 +471,7 @@ async fn test_orchestrator_passes_typed_bls_data() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let received = Arc::new(Mutex::new(None));
     let received_round = Arc::new(Mutex::new(None));
@@ -564,7 +564,7 @@ async fn test_metrics_observed_on_quorum_path() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let orchestrator = builder
         .build(
@@ -639,7 +639,7 @@ async fn test_metrics_round_timeout_counted() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let orchestrator = builder
         .build(
@@ -722,7 +722,7 @@ async fn test_get_payload_not_recalled_after_execution() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_secs(10));
+        .with_round_timeout(Duration::from_secs(10));
 
     let executor = MockExecutor::new();
     let validator = MockValidator::new_success(1);
@@ -814,7 +814,7 @@ async fn test_orchestrator_survives_wait_for_new_round_error() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_secs(10));
+        .with_round_timeout(Duration::from_secs(10));
 
     let executor = MockExecutor::new();
     let validator = MockValidator::new_success(1);
@@ -862,6 +862,70 @@ async fn test_orchestrator_survives_wait_for_new_round_error() {
         !handle.is_finished(),
         "orchestrator must not panic on wait_for_new_round error; \
          it should log and retry instead of calling .unwrap()"
+    );
+
+    drop(msg_tx);
+    handle.abort();
+}
+
+/// A `rebroadcast_interval` shorter than `round_timeout` causes `Start` to be re-sent
+/// within the same round.  The rebroadcast count increments independently of timeouts;
+/// the round does not start over (rounds_started stays 1) and no timeout fires.
+#[tokio::test(start_paused = true)]
+async fn test_rebroadcast_fires_before_round_timeout() {
+    use bytes::Bytes;
+    use commonware_runtime::Metrics;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map) = contributor::create_test_contributors();
+
+    let builder = OrchestratorBuilder::new(clock.clone(), orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_round_timeout(Duration::from_millis(300))
+        .with_rebroadcast_interval(Duration::from_millis(100));
+
+    let orchestrator = builder
+        .build(
+            MockCreator::<TestTaskData>::new(),
+            MockExecutor::new(),
+            MockValidator::new_success(1),
+        )
+        .expect("failed to build orchestrator");
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Let the orchestrator register its timers, then advance past the first
+    // rebroadcast_interval (100ms) but well short of round_timeout (300ms).
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(100)).await;
+    tokio::task::yield_now().await;
+
+    let encoded = clock.encode();
+
+    // The initial broadcast plus one rebroadcast within the same round.
+    assert!(
+        encoded.contains("orchestrator_round_broadcasts_total 2"),
+        "expected two broadcasts (initial + rebroadcast) but got:\n{encoded}"
+    );
+    // The round has not timed out — still on round 1.
+    assert!(
+        encoded.contains("orchestrator_rounds_started_total 1"),
+        "expected round 1 to still be open but got:\n{encoded}"
+    );
+    // No timeout has fired.
+    assert!(
+        !encoded.contains("orchestrator_round_timeouts_total 1"),
+        "expected no timeout yet but got:\n{encoded}"
     );
 
     drop(msg_tx);

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -687,6 +687,78 @@ async fn test_metrics_round_timeout_counted() {
     handle.abort();
 }
 
+/// With a short `round_timeout` and a long `rebroadcast_interval`, the orchestrator
+/// abandons rounds quickly without amplifying `Start` broadcasts.  Each round produces
+/// exactly one broadcast (the initial one); the rebroadcast timer never fires within
+/// any round because `rebroadcast_interval >> round_timeout`.
+///
+/// This is the core safety property of the decoupled knobs: operators can shrink
+/// `round_timeout` for fast recovery without flooding the P2P channel with `Start`
+/// messages.
+#[tokio::test(start_paused = true)]
+async fn test_short_round_timeout_no_rebroadcast_storm() {
+    use bytes::Bytes;
+    use commonware_runtime::Metrics;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map) = contributor::create_test_contributors();
+
+    // round_timeout=100ms, rebroadcast_interval=10s: the rebroadcast timer never
+    // fires during any round because the round times out first.
+    let builder = OrchestratorBuilder::new(clock.clone(), orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_round_timeout(Duration::from_millis(100))
+        .with_rebroadcast_interval(Duration::from_secs(10));
+
+    let orchestrator = builder
+        .build(
+            MockCreator::<TestTaskData>::new(),
+            MockExecutor::new(),
+            MockValidator::new_success(1),
+        )
+        .expect("failed to build orchestrator");
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Each round's timer is registered as tokio::time::sleep(100ms) from the moment
+    // MockClock::sleep_until is called, so it fires 100ms of tokio-time after that
+    // call — not at a fixed absolute offset. To drive N timeouts we must interleave
+    // yield (let the task register the next timer) and advance (fire it).
+    tokio::task::yield_now().await; // round 1 starts, registers sleep(100ms)
+    for _ in 0..3 {
+        tokio::time::advance(Duration::from_millis(100)).await; // fire current round's timer
+        tokio::task::yield_now().await; // process timeout, start next round
+    }
+
+    let encoded = clock.encode();
+
+    // 3 timeouts, 4 rounds started (round 4 open), 4 broadcasts.
+    // broadcasts_total == rounds_started proves exactly one Start per round: no storm.
+    for expected in [
+        "orchestrator_round_timeouts_total 3",
+        "orchestrator_rounds_started_total 4",
+        "orchestrator_round_broadcasts_total 4",
+    ] {
+        assert!(
+            encoded.contains(expected),
+            "expected `{expected}` in encoded metrics:\n{encoded}"
+        );
+    }
+
+    drop(msg_tx);
+    handle.abort();
+}
+
 /// After a successful execution the orchestrator must use the `(payload, round)` returned by
 /// `wait_for_new_round` directly for the next broadcast rather than discarding that result and
 /// calling `get_payload_and_round` a second time. Calling `get_payload_and_round` an extra

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -226,7 +226,8 @@ where
             let round_timeout_deadline = self.runtime.current() + self.round_timeout;
             let mut executed_round: Option<u64> = None;
             let mut rebroadcast_fut = std::pin::pin!(
-                self.runtime.sleep_until(self.runtime.current() + self.rebroadcast_interval)
+                self.runtime
+                    .sleep_until(self.runtime.current() + self.rebroadcast_interval)
             );
             loop {
                 tokio::select! {

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -7,7 +7,6 @@ use commonware_avs_core::validator::ValidatorTrait;
 use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
 use commonware_codec::{EncodeSize, ReadExt, Write};
 use commonware_cryptography::{Hasher, Sha256, Verifier};
-use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
 use commonware_runtime::telemetry::metrics::histogram::HistogramExt;
 use commonware_runtime::telemetry::metrics::status::{CounterExt, Status};
@@ -28,7 +27,10 @@ use crate::orchestrator::traits::OrchestratorTrait;
 /// Configuration for the generic orchestrator
 #[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    pub aggregation_timeout: Duration,
+    /// Max duration to wait for operator signatures before abandoning a round.
+    pub round_timeout: Duration,
+    /// How often to re-send the `Start` broadcast for an in-flight round.
+    pub rebroadcast_interval: Duration,
     pub contributors: Vec<PublicKey>,
     pub g1_map: HashMap<PublicKey, G1PublicKey>,
     pub threshold: usize,
@@ -58,7 +60,8 @@ where
     runtime: C,
     #[allow(dead_code)]
     signer: Bn254,
-    aggregation_timeout: Duration,
+    round_timeout: Duration,
+    rebroadcast_interval: Duration,
     contributors: Vec<PublicKey>,
     g1_map: HashMap<PublicKey, G1PublicKey>, // g2 (PublicKey) -> g1 (PublicKey)
     ordered_contributors: HashMap<PublicKey, usize>,
@@ -121,7 +124,8 @@ where
         Self {
             runtime,
             signer,
-            aggregation_timeout: config.aggregation_timeout,
+            round_timeout: config.round_timeout,
+            rebroadcast_interval: config.rebroadcast_interval,
             contributors,
             g1_map: config.g1_map,
             ordered_contributors,
@@ -210,14 +214,45 @@ where
                 Entry::Occupied(_) => {}
             }
 
-            // Listen for messages until the next broadcast
-            let continue_time = self.runtime.current() + self.aggregation_timeout;
+            // Collect signatures until the round times out or reaches the threshold.
+            // The rebroadcast timer re-sends `Start` for the same round on a shorter
+            // cadence so nodes that missed the first broadcast can still sign; it is
+            // independent of round_timeout so operators can set a fast recovery window
+            // without flooding the network with Start messages.
+            //
+            // biased: round_timeout is checked first so it wins when both it and the
+            // rebroadcast timer fire simultaneously (round_timeout == rebroadcast_interval),
+            // preserving the original single-knob behaviour.
+            let round_timeout_deadline = self.runtime.current() + self.round_timeout;
             let mut executed_round: Option<u64> = None;
+            let mut rebroadcast_fut = std::pin::pin!(
+                self.runtime.sleep_until(self.runtime.current() + self.rebroadcast_interval)
+            );
             loop {
-                select! {
-                    _ = self.runtime.sleep_until(continue_time) => {
+                tokio::select! {
+                    biased;
+                    _ = self.runtime.sleep_until(round_timeout_deadline) => {
                         self.metrics.round_timeouts.inc();
                         break;
+                    },
+                    _ = &mut rebroadcast_fut => {
+                        let task_data = self.task_creator.get_task_metadata();
+                        let rebroadcast_msg = Aggregation::<TC::TaskData>::new(
+                            current_round,
+                            task_data,
+                            Some(Payload::Start),
+                        );
+                        let mut buf = Vec::with_capacity(rebroadcast_msg.encode_size());
+                        rebroadcast_msg.write(&mut buf);
+                        sender
+                            .send(commonware_p2p::Recipients::All, Bytes::from(buf), true)
+                            .await
+                            .expect("failed to rebroadcast Start");
+                        self.metrics.round_broadcasts.inc();
+                        rebroadcast_fut.set(
+                            self.runtime
+                                .sleep_until(self.runtime.current() + self.rebroadcast_interval),
+                        );
                     },
                     msg = receiver.recv() => {
                         // Parse message


### PR DESCRIPTION
## Summary

- Splits the single `aggregation_timeout` knob into two independent fields: `round_timeout` (how long to wait for threshold signatures before abandoning a round) and `rebroadcast_interval` (how often to re-send `Start` for an in-flight round)
- Inner loop is now a 3-branch biased `tokio::select!` — round_timeout checked first so it wins when both timers fire simultaneously, then rebroadcast re-send with timer reset, then receiver
- `AGGREGATION_TIMEOUT` env var and `with_aggregation_timeout` builder method removed (breaking change); replaced by `ROUND_TIMEOUT` / `REBROADCAST_INTERVAL` and `with_round_timeout` / `with_rebroadcast_interval`

## Test plan

- [ ] All 47 existing tests pass
- [ ] `test_builder_with_round_timeout_and_rebroadcast_interval` — independent knob configuration
- [ ] `test_rebroadcast_fires_before_round_timeout` — rebroadcast fires at 100ms within a 300ms round without triggering a timeout
- [ ] `test_metrics_round_timeout_counted` — short round_timeout with long default rebroadcast_interval produces no intra-round broadcast storm

Closes #164