### PR TITLE
feat: introduce DurationProvider for dynamic round_timeout and rebroadcast_interval

### DIFF
--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tracing::info;
 
+use crate::orchestrator::types::{DurationProvider, constant_duration};
+
 use crate::executor::{FromBlsAggregation, VerificationData, VerificationExecutor};
 
 /// Fallible orchestrator construction, parameterized by the verification-data container
@@ -26,15 +28,15 @@ pub struct OrchestratorBuilderConfig<C: Clock + Metrics> {
 ///
 /// This struct holds all the configuration parameters needed
 /// to construct an orchestrator instance.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OrchestratorConfig {
-    /// Max duration to wait for operator signatures before abandoning a round.
-    pub round_timeout: Duration,
-    /// How often to re-send the `Start` broadcast for an in-flight round while waiting
-    /// for signatures. Independent from `round_timeout` so recovery can be fast without
-    /// amplifying `Start` broadcasts. When equal to `round_timeout`, no intra-round
-    /// rebroadcast fires (the round times out first under the biased select).
-    pub rebroadcast_interval: Duration,
+    /// Provider for the max duration to wait for operator signatures before abandoning a round.
+    pub round_timeout: DurationProvider,
+    /// Provider for how often to re-send the `Start` broadcast for an in-flight round.
+    /// Independent from `round_timeout` so recovery can be fast without amplifying broadcasts.
+    /// When the sampled value equals `round_timeout`'s sampled value, the biased select
+    /// ensures no intra-round rebroadcast fires.
+    pub rebroadcast_interval: DurationProvider,
     /// The threshold number of signatures required for aggregation
     pub threshold: usize,
     /// Whether to use ingress mode (HTTP server for external requests)
@@ -46,12 +48,24 @@ pub struct OrchestratorConfig {
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
-            round_timeout: Duration::from_secs(30),
-            rebroadcast_interval: Duration::from_secs(30),
+            round_timeout: constant_duration(Duration::from_secs(30)),
+            rebroadcast_interval: constant_duration(Duration::from_secs(30)),
             threshold: 3,
             use_ingress: false,
             ingress_address: "0.0.0.0:8080".to_string(),
         }
+    }
+}
+
+impl std::fmt::Debug for OrchestratorConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OrchestratorConfig")
+            .field("round_timeout", &(self.round_timeout)())
+            .field("rebroadcast_interval", &(self.rebroadcast_interval)())
+            .field("threshold", &self.threshold)
+            .field("use_ingress", &self.use_ingress)
+            .field("ingress_address", &self.ingress_address)
+            .finish()
     }
 }
 
@@ -112,23 +126,42 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         self
     }
 
-    /// Sets the round timeout.
+    /// Sets a fixed round timeout.
     ///
     /// Max duration to wait for operator signatures before abandoning a round.
     #[allow(dead_code)]
     pub fn with_round_timeout(mut self, timeout: Duration) -> Self {
-        self.config.round_timeout = timeout;
+        self.config.round_timeout = constant_duration(timeout);
         self
     }
 
-    /// Sets the rebroadcast interval.
+    /// Sets a dynamic round timeout provider.
+    ///
+    /// The provider is called once per round; returning different values across calls
+    /// lets callers adapt the timeout at runtime (e.g. based on chain conditions).
+    #[allow(dead_code)]
+    pub fn with_round_timeout_provider(mut self, provider: DurationProvider) -> Self {
+        self.config.round_timeout = provider;
+        self
+    }
+
+    /// Sets a fixed rebroadcast interval.
     ///
     /// How often to re-send the `Start` broadcast for an in-flight round while waiting
     /// for signatures. Setting this longer than `round_timeout` disables intra-round
     /// rebroadcasting entirely.
     #[allow(dead_code)]
     pub fn with_rebroadcast_interval(mut self, interval: Duration) -> Self {
-        self.config.rebroadcast_interval = interval;
+        self.config.rebroadcast_interval = constant_duration(interval);
+        self
+    }
+
+    /// Sets a dynamic rebroadcast interval provider.
+    ///
+    /// The provider is called each time the rebroadcast timer is reset.
+    #[allow(dead_code)]
+    pub fn with_rebroadcast_interval_provider(mut self, provider: DurationProvider) -> Self {
+        self.config.rebroadcast_interval = provider;
         self
     }
 
@@ -185,7 +218,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         if let Ok(val) = std::env::var("ROUND_TIMEOUT")
             && let Ok(seconds) = val.parse::<f64>()
         {
-            self.config.round_timeout = Duration::from_secs_f64(seconds);
+            self.config.round_timeout = constant_duration(Duration::from_secs_f64(seconds));
             info!(
                 "round_timeout set to {} seconds from ROUND_TIMEOUT",
                 seconds
@@ -196,7 +229,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         if let Ok(val) = std::env::var("REBROADCAST_INTERVAL")
             && let Ok(seconds) = val.parse::<f64>()
         {
-            self.config.rebroadcast_interval = Duration::from_secs_f64(seconds);
+            self.config.rebroadcast_interval = constant_duration(Duration::from_secs_f64(seconds));
             info!(
                 "rebroadcast_interval set to {} seconds from REBROADCAST_INTERVAL",
                 seconds
@@ -246,8 +279,8 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            round_timeout = ?self.config.round_timeout,
-            rebroadcast_interval = ?self.config.rebroadcast_interval,
+            round_timeout_ms = (self.config.round_timeout)().as_millis(),
+            rebroadcast_interval_ms = (self.config.rebroadcast_interval)().as_millis(),
             use_ingress = self.config.use_ingress,
             "Validated orchestrator configuration"
         );
@@ -311,8 +344,8 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            round_timeout = ?self.config.round_timeout,
-            rebroadcast_interval = ?self.config.rebroadcast_interval,
+            round_timeout_ms = (self.config.round_timeout)().as_millis(),
+            rebroadcast_interval_ms = (self.config.rebroadcast_interval)().as_millis(),
             "Building generic orchestrator"
         );
 

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -25,8 +25,11 @@ async fn test_builder_new() {
     let config = builder.get_config().expect("Failed to get config");
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
-    assert_eq!(config.config.round_timeout, Duration::from_secs(30));
-    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(30));
+    assert_eq!((config.config.round_timeout)(), Duration::from_secs(30));
+    assert_eq!(
+        (config.config.rebroadcast_interval)(),
+        Duration::from_secs(30)
+    );
     assert_eq!(config.config.threshold, 3);
 }
 
@@ -90,8 +93,8 @@ async fn test_builder_with_round_timeout_and_rebroadcast_interval() {
         .with_rebroadcast_interval(rebroadcast_interval);
 
     let config = builder.get_config().expect("Failed to get config");
-    assert_eq!(config.config.round_timeout, round_timeout);
-    assert_eq!(config.config.rebroadcast_interval, rebroadcast_interval);
+    assert_eq!((config.config.round_timeout)(), round_timeout);
+    assert_eq!((config.config.rebroadcast_interval)(), rebroadcast_interval);
 }
 
 #[tokio::test]
@@ -134,8 +137,11 @@ async fn test_builder_load_from_env() {
     let config = builder.get_config().expect("Failed to get config");
     assert!(config.config.use_ingress);
     assert_eq!(config.config.ingress_address, "0.0.0.0:9090");
-    assert_eq!(config.config.round_timeout, Duration::from_secs(45));
-    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(5));
+    assert_eq!((config.config.round_timeout)(), Duration::from_secs(45));
+    assert_eq!(
+        (config.config.rebroadcast_interval)(),
+        Duration::from_secs(5)
+    );
     assert_eq!(config.config.threshold, 7);
 
     // Clean up environment variables
@@ -208,8 +214,11 @@ async fn test_builder_get_config() {
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
     assert_eq!(config.config.threshold, 5);
-    assert_eq!(config.config.round_timeout, Duration::from_secs(60));
-    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(15));
+    assert_eq!((config.config.round_timeout)(), Duration::from_secs(60));
+    assert_eq!(
+        (config.config.rebroadcast_interval)(),
+        Duration::from_secs(15)
+    );
 }
 
 #[tokio::test]

--- a/router/src/orchestrator/tests/generic.rs
+++ b/router/src/orchestrator/tests/generic.rs
@@ -2,7 +2,7 @@ use super::task_data::TestTaskData;
 use crate::creator::Creator;
 use crate::creator::MockCreator;
 use crate::executor::MockExecutor;
-use crate::orchestrator::types::{Orchestrator, OrchestratorConfig};
+use crate::orchestrator::types::{Orchestrator, OrchestratorConfig, constant_duration};
 use commonware_avs_core::validator::MockValidator;
 use std::time::Duration;
 
@@ -16,8 +16,8 @@ async fn test_orchestrator_new() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 2,
@@ -62,8 +62,8 @@ async fn test_orchestrator_task_creator_metadata() {
     };
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,
@@ -94,8 +94,8 @@ async fn test_orchestrator_executor_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,
@@ -126,8 +126,8 @@ async fn test_orchestrator_validator_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,
@@ -158,8 +158,8 @@ async fn test_orchestrator_config_creation() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(45),
-        rebroadcast_interval: Duration::from_secs(45),
+        round_timeout: constant_duration(Duration::from_secs(45)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(45)),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3,
@@ -199,8 +199,8 @@ async fn test_orchestrator_threshold_validation() {
 
     // Test with threshold equal to number of contributors
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3, // Equal to number of contributors
@@ -236,8 +236,8 @@ async fn test_orchestrator_component_interaction() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -1003,3 +1003,91 @@ async fn test_rebroadcast_fires_before_round_timeout() {
     drop(msg_tx);
     handle.abort();
 }
+
+/// Verifies that a `DurationProvider` that changes its return value between rounds causes
+/// the orchestrator to apply the new timeout on the next round.
+///
+/// Setup: the provider starts at 300 ms. After the first round times out we bump it to
+/// 100 ms. We then confirm that the second round fires a timeout within 100 ms (not 300 ms),
+/// which would only be possible if `round_timeout` was sampled at the start of each round.
+#[tokio::test(start_paused = true)]
+async fn test_dynamic_round_timeout_provider() {
+    use commonware_runtime::Metrics;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map) = contributor::create_test_contributors();
+
+    // Shared atomic millisecond value — starts at 300 ms, will be lowered to 100 ms.
+    let timeout_ms = Arc::new(AtomicU64::new(300));
+    let timeout_ms_clone = timeout_ms.clone();
+    let provider: crate::orchestrator::types::DurationProvider =
+        Arc::new(move || Duration::from_millis(timeout_ms_clone.load(Ordering::Relaxed)));
+
+    let builder = OrchestratorBuilder::new(clock.clone(), orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_round_timeout_provider(provider)
+        .with_rebroadcast_interval(Duration::from_secs(3600)); // effectively disabled
+
+    let orchestrator = builder
+        .build(
+            MockCreator::<TestTaskData>::new(),
+            MockExecutor::new(),
+            MockValidator::new_success(1),
+        )
+        .expect("failed to build orchestrator");
+
+    let (msg_tx, msg_rx) = tokio::sync::mpsc::unbounded_channel::<(
+        commonware_avs_core::bn254::PublicKey,
+        bytes::Bytes,
+    )>();
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Yield so the orchestrator starts and registers the first round timer at 300 ms.
+    tokio::task::yield_now().await;
+
+    // Change the provider to 100 ms while round 1 is still running. Round 2 will pick
+    // this up when it calls the provider at the start of the new round.
+    timeout_ms.store(100, Ordering::Relaxed);
+
+    // Advance past the first 300 ms timeout — round 1 times out, round 2 starts and
+    // registers a new timer using the updated provider value (100 ms from now).
+    tokio::time::advance(Duration::from_millis(300)).await;
+    tokio::task::yield_now().await;
+
+    let encoded = clock.encode();
+    assert!(
+        encoded.contains("orchestrator_round_timeouts_total 1"),
+        "expected one timeout after 300 ms but got:\n{encoded}"
+    );
+    assert!(
+        encoded.contains("orchestrator_rounds_started_total 2"),
+        "expected round 2 to have started but got:\n{encoded}"
+    );
+
+    // Advance only 100 ms — only sufficient if round 2 used the updated provider (100 ms),
+    // not the stale value (300 ms). Proves the provider is sampled fresh each round.
+    tokio::time::advance(Duration::from_millis(100)).await;
+    tokio::task::yield_now().await;
+
+    let encoded = clock.encode();
+    assert!(
+        encoded.contains("orchestrator_round_timeouts_total 2"),
+        "expected two timeouts — proves provider is sampled each round, but got:\n{encoded}"
+    );
+    assert!(
+        encoded.contains("orchestrator_rounds_started_total 3"),
+        "expected round 3 to have started but got:\n{encoded}"
+    );
+
+    drop(msg_tx);
+    handle.abort();
+}

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -24,13 +24,26 @@ use crate::executor::{FromBlsAggregation, VerificationData, VerificationExecutor
 use crate::orchestrator::metrics::OrchestratorMetrics;
 use crate::orchestrator::traits::OrchestratorTrait;
 
+/// A callable that returns a `Duration`, sampled once per round on the hot path.
+///
+/// Use `constant_duration` for a fixed value, or wrap a shared atomic/`RwLock` to
+/// allow an adaptive controller to adjust the orchestrator's timing live.
+pub type DurationProvider = std::sync::Arc<dyn Fn() -> Duration + Send + Sync>;
+
+/// Returns a `DurationProvider` that always yields `d`.
+pub fn constant_duration(d: Duration) -> DurationProvider {
+    std::sync::Arc::new(move || d)
+}
+
 /// Configuration for the generic orchestrator
-#[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    /// Max duration to wait for operator signatures before abandoning a round.
-    pub round_timeout: Duration,
-    /// How often to re-send the `Start` broadcast for an in-flight round.
-    pub rebroadcast_interval: Duration,
+    /// Called once per round to determine how long to wait for threshold signatures
+    /// before abandoning the round. A dynamic provider lets an adaptive controller
+    /// shrink or grow this window at runtime.
+    pub round_timeout: DurationProvider,
+    /// Called once per round (and again after each rebroadcast) to determine the
+    /// interval between `Start` re-sends for an in-flight round.
+    pub rebroadcast_interval: DurationProvider,
     pub contributors: Vec<PublicKey>,
     pub g1_map: HashMap<PublicKey, G1PublicKey>,
     pub threshold: usize,
@@ -60,8 +73,8 @@ where
     runtime: C,
     #[allow(dead_code)]
     signer: Bn254,
-    round_timeout: Duration,
-    rebroadcast_interval: Duration,
+    round_timeout: DurationProvider,
+    rebroadcast_interval: DurationProvider,
     contributors: Vec<PublicKey>,
     g1_map: HashMap<PublicKey, G1PublicKey>, // g2 (PublicKey) -> g1 (PublicKey)
     ordered_contributors: HashMap<PublicKey, usize>,
@@ -124,8 +137,8 @@ where
         Self {
             runtime,
             signer,
-            round_timeout: config.round_timeout,
-            rebroadcast_interval: config.rebroadcast_interval,
+            round_timeout: config.round_timeout.clone(),
+            rebroadcast_interval: config.rebroadcast_interval.clone(),
             contributors,
             g1_map: config.g1_map,
             ordered_contributors,
@@ -223,11 +236,11 @@ where
             // biased: round_timeout is checked first so it wins when both it and the
             // rebroadcast timer fire simultaneously (round_timeout == rebroadcast_interval),
             // preserving the original single-knob behaviour.
-            let round_timeout_deadline = self.runtime.current() + self.round_timeout;
+            let round_timeout_deadline = self.runtime.current() + (self.round_timeout)();
             let mut executed_round: Option<u64> = None;
             let mut rebroadcast_fut = std::pin::pin!(
                 self.runtime
-                    .sleep_until(self.runtime.current() + self.rebroadcast_interval)
+                    .sleep_until(self.runtime.current() + (self.rebroadcast_interval)())
             );
             loop {
                 tokio::select! {
@@ -252,7 +265,7 @@ where
                         self.metrics.round_broadcasts.inc();
                         rebroadcast_fut.set(
                             self.runtime
-                                .sleep_until(self.runtime.current() + self.rebroadcast_interval),
+                                .sleep_until(self.runtime.current() + (self.rebroadcast_interval)()),
                         );
                     },
                     msg = receiver.recv() => {


### PR DESCRIPTION
## Summary

- Adds `DurationProvider = Arc<dyn Fn() -> Duration + Send + Sync>` type alias and `constant_duration` constructor to `types.rs`
- Changes `OrchestratorConfig.round_timeout` and `rebroadcast_interval` from `Duration` to `DurationProvider`; both fields are sampled once per round/rebroadcast cycle so callers can adapt timing at runtime
- Adds `with_round_timeout_provider` and `with_rebroadcast_interval_provider` builder methods alongside the existing `Duration`-based convenience methods
- Implements a manual `Debug` for `OrchestratorConfig` (samples current values) since `Arc<dyn Fn()>` does not implement `Debug`

## Test plan

- [ ] All 49 existing tests continue to pass (`cargo test --all-targets --all-features`)
- [ ] New integration test `test_dynamic_round_timeout_provider`: sets `provider=300 ms`, lets round 1 time out, updates provider to `100 ms`, advances only 100 ms, and asserts round 2 also times out — proving the provider is sampled fresh each round
- [ ] `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` pass clean