### PR TITLE
feat: orchestrator latency improvements

### DIFF
--- a/example.env
+++ b/example.env
@@ -95,8 +95,8 @@ SIGNER_ENDPOINT=http://signer:50051
 INGRESS=false
 
 # Max seconds to wait for threshold signatures before abandoning a round (supports fractional)
-# ROUND_TIMEOUT=30
+ROUND_TIMEOUT=30
 
 # How often (in seconds) to re-send the Start broadcast for an in-flight round.
 # Set longer than ROUND_TIMEOUT to disable intra-round rebroadcasting entirely.
-# REBROADCAST_INTERVAL=30
+REBROADCAST_INTERVAL=30

--- a/example.env
+++ b/example.env
@@ -94,6 +94,9 @@ SIGNER_ENDPOINT=http://signer:50051
 # =============================================================================
 INGRESS=false
 
-# Aggregation timeout in seconds (supports fractional values)
-# Examples: 30 (default), 1, 0.5, 0.3, 0.1
-# AGGREGATION_TIMEOUT=30
+# Max seconds to wait for threshold signatures before abandoning a round (supports fractional)
+# ROUND_TIMEOUT=30
+
+# How often (in seconds) to re-send the Start broadcast for an in-flight round.
+# Set longer than ROUND_TIMEOUT to disable intra-round rebroadcasting entirely.
+# REBROADCAST_INTERVAL=30

--- a/examples/counter/router/src/creator.rs
+++ b/examples/counter/router/src/creator.rs
@@ -33,6 +33,17 @@ impl Creator for CounterCreator {
         Ok((payload, round))
     }
 
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        loop {
+            let round = self.provider.get_current_round().await?;
+            if round > current {
+                let payload = self.provider.encode_round(round);
+                return Ok((payload, round));
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        }
+    }
+
     fn get_task_metadata(&self) -> Self::TaskData {
         CounterTaskData::default()
     }
@@ -94,6 +105,19 @@ impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningCounterCreator<Q
         Ok((payload, round))
     }
 
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        use tokio::time::{Duration, sleep};
+        loop {
+            let _task = self.wait_for_task().await?;
+            let round = self.provider.get_current_round().await?;
+            if round > current {
+                let payload = self.provider.encode_round(round);
+                return Ok((payload, round));
+            }
+            sleep(Duration::from_millis(self.config.polling_interval_ms)).await;
+        }
+    }
+
     fn get_task_metadata(&self) -> Self::TaskData {
         if let Ok(current_task) = self.current_task.lock()
             && let Some(ref task) = *current_task
@@ -137,6 +161,13 @@ impl Creator for CounterCreatorType {
         match self {
             CounterCreatorType::Basic(creator) => creator.get_payload_and_round().await,
             CounterCreatorType::Listening(creator) => creator.get_payload_and_round().await,
+        }
+    }
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        match self {
+            CounterCreatorType::Basic(creator) => creator.wait_for_new_round(current).await,
+            CounterCreatorType::Listening(creator) => creator.wait_for_new_round(current).await,
         }
     }
 

--- a/examples/counter/router/src/creator.rs
+++ b/examples/counter/router/src/creator.rs
@@ -107,6 +107,8 @@ impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningCounterCreator<Q
 
     async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
         loop {
+            // Block until a new task is queued; the task data itself is not used here,
+            // only the side effect of waiting for the queue to produce a new entry.
             let _task = self.wait_for_task().await?;
             let round = self.provider.get_current_round().await?;
             if round > current {

--- a/examples/counter/router/src/creator.rs
+++ b/examples/counter/router/src/creator.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
+use tokio::time::{Duration, sleep};
 use tracing::error;
 
 use crate::provider::CounterProvider;
@@ -40,7 +41,7 @@ impl Creator for CounterCreator {
                 let payload = self.provider.encode_round(round);
                 return Ok((payload, round));
             }
-            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            sleep(Duration::from_secs(2)).await;
         }
     }
 
@@ -67,7 +68,6 @@ impl<Q: TaskQueue + Send + Sync + 'static> ListeningCounterCreator<Q> {
     }
 
     async fn wait_for_task(&self) -> Result<TaskRequest> {
-        use tokio::time::{Duration, sleep};
         let mut attempts = 0;
         let max_attempts = self.config.timeout_ms / self.config.polling_interval_ms;
         loop {
@@ -106,7 +106,6 @@ impl<Q: TaskQueue + Send + Sync + 'static> Creator for ListeningCounterCreator<Q
     }
 
     async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
-        use tokio::time::{Duration, sleep};
         loop {
             let _task = self.wait_for_task().await?;
             let round = self.provider.get_current_round().await?;

--- a/router/src/creator/tests/mock.rs
+++ b/router/src/creator/tests/mock.rs
@@ -169,8 +169,13 @@ where
         Ok((payload, round))
     }
 
-    async fn wait_for_new_round(&self, _current: u64) -> Result<(Vec<u8>, u64)> {
-        self.get_payload_and_round().await
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        let result = self.get_payload_and_round().await?;
+        assert!(
+            result.1 > current,
+            "mock violated wait_for_new_round contract"
+        );
+        Ok(result)
     }
 
     fn get_task_metadata(&self) -> Self::TaskData {

--- a/router/src/creator/tests/mock.rs
+++ b/router/src/creator/tests/mock.rs
@@ -169,6 +169,10 @@ where
         Ok((payload, round))
     }
 
+    async fn wait_for_new_round(&self, _current: u64) -> Result<(Vec<u8>, u64)> {
+        self.get_payload_and_round().await
+    }
+
     fn get_task_metadata(&self) -> Self::TaskData {
         self.metadata.clone()
     }
@@ -180,5 +184,41 @@ where
 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{Buf, BufMut};
+    use commonware_codec::{EncodeSize, Read, Write};
+
+    #[derive(Clone, Default)]
+    struct NoData;
+
+    impl Write for NoData {
+        fn write(&self, _buf: &mut impl BufMut) {}
+    }
+
+    impl Read for NoData {
+        type Cfg = ();
+        fn read_cfg(_buf: &mut impl Buf, _: &()) -> Result<Self, commonware_codec::Error> {
+            Ok(Self)
+        }
+    }
+
+    impl EncodeSize for NoData {
+        fn encode_size(&self) -> usize {
+            0
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_new_round_returns_strictly_greater_round() {
+        let creator = MockCreator::<NoData>::new();
+        let (_, round) = creator.get_payload_and_round().await.unwrap();
+        assert_eq!(round, 1);
+        let (_, new_round) = creator.wait_for_new_round(round).await.unwrap();
+        assert!(new_round > round);
     }
 }

--- a/router/src/creator/traits.rs
+++ b/router/src/creator/traits.rs
@@ -10,6 +10,12 @@ pub trait Creator: Send + Sync {
     /// Compute and return the payload bytes and associated round.
     async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)>;
 
+    /// Block until the round advances past `current`, then return the new payload and round.
+    ///
+    /// Implementations poll their underlying data source at an appropriate interval. The
+    /// returned round is guaranteed to be strictly greater than `current`.
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)>;
+
     /// Get task metadata as the creator's specific data type.
     ///
     /// These metadata fields are used in the wire protocol messages and are typically

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tracing::info;
 
+use crate::orchestrator::types::{DurationProvider, constant_duration};
+
 use crate::executor::{FromBlsAggregation, VerificationData, VerificationExecutor};
 
 /// Fallible orchestrator construction, parameterized by the verification-data container
@@ -26,15 +28,15 @@ pub struct OrchestratorBuilderConfig<C: Clock + Metrics> {
 ///
 /// This struct holds all the configuration parameters needed
 /// to construct an orchestrator instance.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OrchestratorConfig {
-    /// Max duration to wait for operator signatures before abandoning a round.
-    pub round_timeout: Duration,
-    /// How often to re-send the `Start` broadcast for an in-flight round while waiting
-    /// for signatures. Independent from `round_timeout` so recovery can be fast without
-    /// amplifying `Start` broadcasts. When equal to `round_timeout`, no intra-round
-    /// rebroadcast fires (the round times out first under the biased select).
-    pub rebroadcast_interval: Duration,
+    /// Provider for the max duration to wait for operator signatures before abandoning a round.
+    pub round_timeout: DurationProvider,
+    /// Provider for how often to re-send the `Start` broadcast for an in-flight round.
+    /// Independent from `round_timeout` so recovery can be fast without amplifying broadcasts.
+    /// When the sampled value equals `round_timeout`'s sampled value, the biased select
+    /// ensures no intra-round rebroadcast fires.
+    pub rebroadcast_interval: DurationProvider,
     /// The threshold number of signatures required for aggregation
     pub threshold: usize,
     /// Whether to use ingress mode (HTTP server for external requests)
@@ -46,12 +48,24 @@ pub struct OrchestratorConfig {
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
-            round_timeout: Duration::from_secs(30),
-            rebroadcast_interval: Duration::from_secs(30),
+            round_timeout: constant_duration(Duration::from_secs(30)),
+            rebroadcast_interval: constant_duration(Duration::from_secs(30)),
             threshold: 3,
             use_ingress: false,
             ingress_address: "0.0.0.0:8080".to_string(),
         }
+    }
+}
+
+impl std::fmt::Debug for OrchestratorConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OrchestratorConfig")
+            .field("round_timeout", &(self.round_timeout)())
+            .field("rebroadcast_interval", &(self.rebroadcast_interval)())
+            .field("threshold", &self.threshold)
+            .field("use_ingress", &self.use_ingress)
+            .field("ingress_address", &self.ingress_address)
+            .finish()
     }
 }
 
@@ -112,23 +126,42 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         self
     }
 
-    /// Sets the round timeout.
+    /// Sets a fixed round timeout.
     ///
     /// Max duration to wait for operator signatures before abandoning a round.
     #[allow(dead_code)]
     pub fn with_round_timeout(mut self, timeout: Duration) -> Self {
-        self.config.round_timeout = timeout;
+        self.config.round_timeout = constant_duration(timeout);
         self
     }
 
-    /// Sets the rebroadcast interval.
+    /// Sets a dynamic round timeout provider.
+    ///
+    /// The provider is called once per round; returning different values across calls
+    /// lets callers adapt the timeout at runtime (e.g. based on chain conditions).
+    #[allow(dead_code)]
+    pub fn with_round_timeout_provider(mut self, provider: DurationProvider) -> Self {
+        self.config.round_timeout = provider;
+        self
+    }
+
+    /// Sets a fixed rebroadcast interval.
     ///
     /// How often to re-send the `Start` broadcast for an in-flight round while waiting
     /// for signatures. Setting this longer than `round_timeout` disables intra-round
     /// rebroadcasting entirely.
     #[allow(dead_code)]
     pub fn with_rebroadcast_interval(mut self, interval: Duration) -> Self {
-        self.config.rebroadcast_interval = interval;
+        self.config.rebroadcast_interval = constant_duration(interval);
+        self
+    }
+
+    /// Sets a dynamic rebroadcast interval provider.
+    ///
+    /// The provider is called each time the rebroadcast timer is reset.
+    #[allow(dead_code)]
+    pub fn with_rebroadcast_interval_provider(mut self, provider: DurationProvider) -> Self {
+        self.config.rebroadcast_interval = provider;
         self
     }
 
@@ -185,7 +218,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         if let Ok(val) = std::env::var("ROUND_TIMEOUT")
             && let Ok(seconds) = val.parse::<f64>()
         {
-            self.config.round_timeout = Duration::from_secs_f64(seconds);
+            self.config.round_timeout = constant_duration(Duration::from_secs_f64(seconds));
             info!(
                 "round_timeout set to {} seconds from ROUND_TIMEOUT",
                 seconds
@@ -196,7 +229,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         if let Ok(val) = std::env::var("REBROADCAST_INTERVAL")
             && let Ok(seconds) = val.parse::<f64>()
         {
-            self.config.rebroadcast_interval = Duration::from_secs_f64(seconds);
+            self.config.rebroadcast_interval = constant_duration(Duration::from_secs_f64(seconds));
             info!(
                 "rebroadcast_interval set to {} seconds from REBROADCAST_INTERVAL",
                 seconds
@@ -246,8 +279,8 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            round_timeout = ?self.config.round_timeout,
-            rebroadcast_interval = ?self.config.rebroadcast_interval,
+            round_timeout_ms = (self.config.round_timeout)().as_millis(),
+            rebroadcast_interval_ms = (self.config.rebroadcast_interval)().as_millis(),
             use_ingress = self.config.use_ingress,
             "Validated orchestrator configuration"
         );
@@ -311,8 +344,8 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            round_timeout = ?self.config.round_timeout,
-            rebroadcast_interval = ?self.config.rebroadcast_interval,
+            round_timeout_ms = (self.config.round_timeout)().as_millis(),
+            rebroadcast_interval_ms = (self.config.rebroadcast_interval)().as_millis(),
             "Building generic orchestrator"
         );
 

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -129,7 +129,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
     /// Sets a fixed round timeout.
     ///
     /// Max duration to wait for operator signatures before abandoning a round.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // public API for upstream service crate callers
     pub fn with_round_timeout(mut self, timeout: Duration) -> Self {
         self.config.round_timeout = constant_duration(timeout);
         self
@@ -139,7 +139,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
     ///
     /// The provider is called once per round; returning different values across calls
     /// lets callers adapt the timeout at runtime (e.g. based on chain conditions).
-    #[allow(dead_code)]
+    #[allow(dead_code)] // public API for upstream service crate callers
     pub fn with_round_timeout_provider(mut self, provider: DurationProvider) -> Self {
         self.config.round_timeout = provider;
         self
@@ -150,7 +150,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
     /// How often to re-send the `Start` broadcast for an in-flight round while waiting
     /// for signatures. Setting this longer than `round_timeout` disables intra-round
     /// rebroadcasting entirely.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // public API for upstream service crate callers
     pub fn with_rebroadcast_interval(mut self, interval: Duration) -> Self {
         self.config.rebroadcast_interval = constant_duration(interval);
         self
@@ -159,7 +159,7 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
     /// Sets a dynamic rebroadcast interval provider.
     ///
     /// The provider is called each time the rebroadcast timer is reset.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // public API for upstream service crate callers
     pub fn with_rebroadcast_interval_provider(mut self, provider: DurationProvider) -> Self {
         self.config.rebroadcast_interval = provider;
         self

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -132,7 +132,6 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         self
     }
 
-
     /// Sets the threshold for signature aggregation.
     ///
     /// # Arguments
@@ -187,7 +186,10 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
             && let Ok(seconds) = val.parse::<f64>()
         {
             self.config.round_timeout = Duration::from_secs_f64(seconds);
-            info!("round_timeout set to {} seconds from ROUND_TIMEOUT", seconds);
+            info!(
+                "round_timeout set to {} seconds from ROUND_TIMEOUT",
+                seconds
+            );
         }
 
         // REBROADCAST_INTERVAL overrides only the intra-round Start re-send cadence.

--- a/router/src/orchestrator/builder.rs
+++ b/router/src/orchestrator/builder.rs
@@ -28,8 +28,13 @@ pub struct OrchestratorBuilderConfig<C: Clock + Metrics> {
 /// to construct an orchestrator instance.
 #[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    /// Max duration to wait for operator signatures before abandoning a round
-    pub aggregation_timeout: Duration,
+    /// Max duration to wait for operator signatures before abandoning a round.
+    pub round_timeout: Duration,
+    /// How often to re-send the `Start` broadcast for an in-flight round while waiting
+    /// for signatures. Independent from `round_timeout` so recovery can be fast without
+    /// amplifying `Start` broadcasts. When equal to `round_timeout`, no intra-round
+    /// rebroadcast fires (the round times out first under the biased select).
+    pub rebroadcast_interval: Duration,
     /// The threshold number of signatures required for aggregation
     pub threshold: usize,
     /// Whether to use ingress mode (HTTP server for external requests)
@@ -41,7 +46,8 @@ pub struct OrchestratorConfig {
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
-            aggregation_timeout: Duration::from_secs(30),
+            round_timeout: Duration::from_secs(30),
+            rebroadcast_interval: Duration::from_secs(30),
             threshold: 3,
             use_ingress: false,
             ingress_address: "0.0.0.0:8080".to_string(),
@@ -106,18 +112,26 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         self
     }
 
-    /// Sets the aggregation timeout.
+    /// Sets the round timeout.
     ///
-    /// # Arguments
-    /// * `timeout` - Max duration to wait for operator signatures before abandoning a round
-    ///
-    /// # Returns
-    /// * `Self` - The builder for method chaining
+    /// Max duration to wait for operator signatures before abandoning a round.
     #[allow(dead_code)]
-    pub fn with_aggregation_timeout(mut self, timeout: Duration) -> Self {
-        self.config.aggregation_timeout = timeout;
+    pub fn with_round_timeout(mut self, timeout: Duration) -> Self {
+        self.config.round_timeout = timeout;
         self
     }
+
+    /// Sets the rebroadcast interval.
+    ///
+    /// How often to re-send the `Start` broadcast for an in-flight round while waiting
+    /// for signatures. Setting this longer than `round_timeout` disables intra-round
+    /// rebroadcasting entirely.
+    #[allow(dead_code)]
+    pub fn with_rebroadcast_interval(mut self, interval: Duration) -> Self {
+        self.config.rebroadcast_interval = interval;
+        self
+    }
+
 
     /// Sets the threshold for signature aggregation.
     ///
@@ -169,13 +183,20 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
             self.config.ingress_address = address;
         }
 
-        // Check for aggregation timeout (supports fractional seconds)
-        if let Ok(timeout) = std::env::var("AGGREGATION_TIMEOUT")
-            && let Ok(seconds) = timeout.parse::<f64>()
+        if let Ok(val) = std::env::var("ROUND_TIMEOUT")
+            && let Ok(seconds) = val.parse::<f64>()
         {
-            self.config.aggregation_timeout = Duration::from_secs_f64(seconds);
+            self.config.round_timeout = Duration::from_secs_f64(seconds);
+            info!("round_timeout set to {} seconds from ROUND_TIMEOUT", seconds);
+        }
+
+        // REBROADCAST_INTERVAL overrides only the intra-round Start re-send cadence.
+        if let Ok(val) = std::env::var("REBROADCAST_INTERVAL")
+            && let Ok(seconds) = val.parse::<f64>()
+        {
+            self.config.rebroadcast_interval = Duration::from_secs_f64(seconds);
             info!(
-                "Aggregation timeout set to {} seconds from environment",
+                "rebroadcast_interval set to {} seconds from REBROADCAST_INTERVAL",
                 seconds
             );
         }
@@ -223,7 +244,8 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            aggregation_timeout = ?self.config.aggregation_timeout,
+            round_timeout = ?self.config.round_timeout,
+            rebroadcast_interval = ?self.config.rebroadcast_interval,
             use_ingress = self.config.use_ingress,
             "Validated orchestrator configuration"
         );
@@ -287,12 +309,14 @@ impl<C: Clock + Metrics> OrchestratorBuilder<C> {
         info!(
             contributors = self.contributors.len(),
             threshold = self.config.threshold,
-            aggregation_timeout = ?self.config.aggregation_timeout,
+            round_timeout = ?self.config.round_timeout,
+            rebroadcast_interval = ?self.config.rebroadcast_interval,
             "Building generic orchestrator"
         );
 
         let config = crate::orchestrator::types::OrchestratorConfig {
-            aggregation_timeout: self.config.aggregation_timeout,
+            round_timeout: self.config.round_timeout,
+            rebroadcast_interval: self.config.rebroadcast_interval,
             contributors: self.contributors,
             g1_map: self.g1_map,
             threshold: self.config.threshold,

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -25,7 +25,8 @@ async fn test_builder_new() {
     let config = builder.get_config().expect("Failed to get config");
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
-    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(30));
+    assert_eq!(config.config.round_timeout, Duration::from_secs(30));
+    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(30));
     assert_eq!(config.config.threshold, 3);
 }
 
@@ -74,20 +75,24 @@ async fn test_builder_with_threshold() {
     assert_eq!(config.config.threshold, 5);
 }
 
+
 #[tokio::test]
-async fn test_builder_with_aggregation_timeout() {
+async fn test_builder_with_round_timeout_and_rebroadcast_interval() {
     let clock = MockClock::new();
     let signer = signer::create_test_signer();
     let (contributors, g1_map) = contributor::create_test_contributors();
-    let timeout = Duration::from_secs(60);
+    let round_timeout = Duration::from_secs(60);
+    let rebroadcast_interval = Duration::from_secs(10);
 
     let builder = OrchestratorBuilder::new(clock.clone(), signer)
         .with_contributors(contributors)
         .with_g1_map(g1_map)
-        .with_aggregation_timeout(timeout);
+        .with_round_timeout(round_timeout)
+        .with_rebroadcast_interval(rebroadcast_interval);
 
     let config = builder.get_config().expect("Failed to get config");
-    assert_eq!(config.config.aggregation_timeout, timeout);
+    assert_eq!(config.config.round_timeout, round_timeout);
+    assert_eq!(config.config.rebroadcast_interval, rebroadcast_interval);
 }
 
 #[tokio::test]
@@ -117,7 +122,8 @@ async fn test_builder_load_from_env() {
     unsafe {
         std::env::set_var("INGRESS", "true");
         std::env::set_var("INGRESS_ADDRESS", "0.0.0.0:9090");
-        std::env::set_var("AGGREGATION_TIMEOUT", "45");
+        std::env::set_var("ROUND_TIMEOUT", "45");
+        std::env::set_var("REBROADCAST_INTERVAL", "5");
         std::env::set_var("THRESHOLD", "7");
     }
 
@@ -129,14 +135,16 @@ async fn test_builder_load_from_env() {
     let config = builder.get_config().expect("Failed to get config");
     assert!(config.config.use_ingress);
     assert_eq!(config.config.ingress_address, "0.0.0.0:9090");
-    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(45));
+    assert_eq!(config.config.round_timeout, Duration::from_secs(45));
+    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(5));
     assert_eq!(config.config.threshold, 7);
 
     // Clean up environment variables
     unsafe {
         std::env::remove_var("INGRESS");
         std::env::remove_var("INGRESS_ADDRESS");
-        std::env::remove_var("AGGREGATION_TIMEOUT");
+        std::env::remove_var("ROUND_TIMEOUT");
+        std::env::remove_var("REBROADCAST_INTERVAL");
         std::env::remove_var("THRESHOLD");
     }
 }
@@ -193,14 +201,16 @@ async fn test_builder_get_config() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(5)
-        .with_aggregation_timeout(Duration::from_secs(60));
+        .with_round_timeout(Duration::from_secs(60))
+        .with_rebroadcast_interval(Duration::from_secs(15));
 
     let config = builder.get_config().expect("Failed to get config");
 
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
     assert_eq!(config.config.threshold, 5);
-    assert_eq!(config.config.aggregation_timeout, Duration::from_secs(60));
+    assert_eq!(config.config.round_timeout, Duration::from_secs(60));
+    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(15));
 }
 
 #[tokio::test]

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -25,8 +25,11 @@ async fn test_builder_new() {
     let config = builder.get_config().expect("Failed to get config");
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
-    assert_eq!(config.config.round_timeout, Duration::from_secs(30));
-    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(30));
+    assert_eq!((config.config.round_timeout)(), Duration::from_secs(30));
+    assert_eq!(
+        (config.config.rebroadcast_interval)(),
+        Duration::from_secs(30)
+    );
     assert_eq!(config.config.threshold, 3);
 }
 
@@ -90,8 +93,8 @@ async fn test_builder_with_round_timeout_and_rebroadcast_interval() {
         .with_rebroadcast_interval(rebroadcast_interval);
 
     let config = builder.get_config().expect("Failed to get config");
-    assert_eq!(config.config.round_timeout, round_timeout);
-    assert_eq!(config.config.rebroadcast_interval, rebroadcast_interval);
+    assert_eq!((config.config.round_timeout)(), round_timeout);
+    assert_eq!((config.config.rebroadcast_interval)(), rebroadcast_interval);
 }
 
 #[tokio::test]
@@ -134,8 +137,11 @@ async fn test_builder_load_from_env() {
     let config = builder.get_config().expect("Failed to get config");
     assert!(config.config.use_ingress);
     assert_eq!(config.config.ingress_address, "0.0.0.0:9090");
-    assert_eq!(config.config.round_timeout, Duration::from_secs(45));
-    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(5));
+    assert_eq!((config.config.round_timeout)(), Duration::from_secs(45));
+    assert_eq!(
+        (config.config.rebroadcast_interval)(),
+        Duration::from_secs(5)
+    );
     assert_eq!(config.config.threshold, 7);
 
     // Clean up environment variables
@@ -208,8 +214,11 @@ async fn test_builder_get_config() {
     assert_eq!(config.contributors.len(), 3);
     assert_eq!(config.g1_map.len(), 3);
     assert_eq!(config.config.threshold, 5);
-    assert_eq!(config.config.round_timeout, Duration::from_secs(60));
-    assert_eq!(config.config.rebroadcast_interval, Duration::from_secs(15));
+    assert_eq!((config.config.round_timeout)(), Duration::from_secs(60));
+    assert_eq!(
+        (config.config.rebroadcast_interval)(),
+        Duration::from_secs(15)
+    );
 }
 
 #[tokio::test]

--- a/router/src/orchestrator/tests/builder.rs
+++ b/router/src/orchestrator/tests/builder.rs
@@ -75,7 +75,6 @@ async fn test_builder_with_threshold() {
     assert_eq!(config.config.threshold, 5);
 }
 
-
 #[tokio::test]
 async fn test_builder_with_round_timeout_and_rebroadcast_interval() {
     let clock = MockClock::new();

--- a/router/src/orchestrator/tests/generic.rs
+++ b/router/src/orchestrator/tests/generic.rs
@@ -16,7 +16,8 @@ async fn test_orchestrator_new() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 2,
@@ -61,7 +62,8 @@ async fn test_orchestrator_task_creator_metadata() {
     };
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -92,7 +94,8 @@ async fn test_orchestrator_executor_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -123,7 +126,8 @@ async fn test_orchestrator_validator_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,
@@ -154,7 +158,8 @@ async fn test_orchestrator_config_creation() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(45),
+        round_timeout: Duration::from_secs(45),
+        rebroadcast_interval: Duration::from_secs(45),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3,
@@ -194,7 +199,8 @@ async fn test_orchestrator_threshold_validation() {
 
     // Test with threshold equal to number of contributors
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3, // Equal to number of contributors
@@ -230,7 +236,8 @@ async fn test_orchestrator_component_interaction() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        aggregation_timeout: Duration::from_secs(30),
+        round_timeout: Duration::from_secs(30),
+        rebroadcast_interval: Duration::from_secs(30),
         contributors,
         g1_map,
         threshold: 2,

--- a/router/src/orchestrator/tests/generic.rs
+++ b/router/src/orchestrator/tests/generic.rs
@@ -2,7 +2,7 @@ use super::task_data::TestTaskData;
 use crate::creator::Creator;
 use crate::creator::MockCreator;
 use crate::executor::MockExecutor;
-use crate::orchestrator::types::{Orchestrator, OrchestratorConfig};
+use crate::orchestrator::types::{Orchestrator, OrchestratorConfig, constant_duration};
 use commonware_avs_core::validator::MockValidator;
 use std::time::Duration;
 
@@ -16,8 +16,8 @@ async fn test_orchestrator_new() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 2,
@@ -62,8 +62,8 @@ async fn test_orchestrator_task_creator_metadata() {
     };
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,
@@ -94,8 +94,8 @@ async fn test_orchestrator_executor_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,
@@ -126,8 +126,8 @@ async fn test_orchestrator_validator_access() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,
@@ -158,8 +158,8 @@ async fn test_orchestrator_config_creation() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(45),
-        rebroadcast_interval: Duration::from_secs(45),
+        round_timeout: constant_duration(Duration::from_secs(45)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(45)),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3,
@@ -199,8 +199,8 @@ async fn test_orchestrator_threshold_validation() {
 
     // Test with threshold equal to number of contributors
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors: contributors.clone(),
         g1_map: g1_map.clone(),
         threshold: 3, // Equal to number of contributors
@@ -236,8 +236,8 @@ async fn test_orchestrator_component_interaction() {
     let (contributors, g1_map) = contributor::create_test_contributors();
 
     let config = OrchestratorConfig {
-        round_timeout: Duration::from_secs(30),
-        rebroadcast_interval: Duration::from_secs(30),
+        round_timeout: constant_duration(Duration::from_secs(30)),
+        rebroadcast_interval: constant_duration(Duration::from_secs(30)),
         contributors,
         g1_map,
         threshold: 2,

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -5,14 +5,79 @@ use crate::executor::bls::BlsVerificationData;
 use crate::executor::{ExecutionResult, MockExecutor, VerificationExecutor};
 use crate::orchestrator::builder::OrchestratorBuilder;
 use crate::orchestrator::traits::OrchestratorTrait;
+use anyhow::Result;
 use async_trait::async_trait;
 use commonware_avs_core::validator::MockValidator;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::helpers::{contributor, signer};
 use super::mocks::clock::MockClock;
 use super::mocks::{MockReceiver, MockSender};
+
+/// Wraps a `MockCreator` and separately counts calls to `get_payload_and_round` vs
+/// `wait_for_new_round`. Used to assert that the orchestrator does not re-call
+/// `get_payload_and_round` after a successful execution (the double-consume bug).
+struct TrackingCreator {
+    inner: MockCreator<TestTaskData>,
+    get_count: Arc<AtomicUsize>,
+    wait_count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Creator for TrackingCreator {
+    type TaskData = TestTaskData;
+
+    async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)> {
+        self.get_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.get_payload_and_round().await
+    }
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        self.wait_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.wait_for_new_round(current).await
+    }
+
+    fn get_task_metadata(&self) -> TestTaskData {
+        self.inner.get_task_metadata()
+    }
+}
+
+/// Returns `Err` on the first call to `wait_for_new_round`, then delegates to the inner
+/// creator. Used to assert that the orchestrator handles the error gracefully (no panic)
+/// rather than unwrapping.
+struct ErrorOnceCreator {
+    inner: MockCreator<TestTaskData>,
+    first_wait: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl Creator for ErrorOnceCreator {
+    type TaskData = TestTaskData;
+
+    async fn get_payload_and_round(&self) -> Result<(Vec<u8>, u64)> {
+        self.inner.get_payload_and_round().await
+    }
+
+    async fn wait_for_new_round(&self, current: u64) -> Result<(Vec<u8>, u64)> {
+        let is_first = {
+            let mut guard = self.first_wait.lock().unwrap();
+            let was = *guard;
+            *guard = false;
+            was
+        };
+        if is_first {
+            Err(anyhow::anyhow!("simulated queue timeout"))
+        } else {
+            self.inner.wait_for_new_round(current).await
+        }
+    }
+
+    fn get_task_metadata(&self) -> TestTaskData {
+        self.inner.get_task_metadata()
+    }
+}
 
 #[tokio::test]
 async fn test_orchestrator_builder_integration() {
@@ -617,6 +682,187 @@ async fn test_metrics_round_timeout_counted() {
             "expected `{expected}` in encoded metrics:\n{encoded}"
         );
     }
+
+    drop(msg_tx);
+    handle.abort();
+}
+
+/// After a successful execution the orchestrator must use the `(payload, round)` returned by
+/// `wait_for_new_round` directly for the next broadcast rather than discarding that result and
+/// calling `get_payload_and_round` a second time. Calling `get_payload_and_round` an extra
+/// time per executed round causes double-consumption of queue-backed creators:
+/// `ListeningCounterCreator` pops a task from the shared queue on every call, so the extra
+/// call silently discards the task that should drive the next round.
+#[tokio::test(start_paused = true)]
+async fn test_get_payload_not_recalled_after_execution() {
+    use alloy::primitives::U256;
+    use alloy::sol_types::SolValue;
+    use bytes::Bytes;
+    use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
+    use commonware_codec::{EncodeSize, Write};
+    use commonware_cryptography::{Hasher, Sha256, Signer};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map, contributor_signers) =
+        contributor::create_test_contributors_with_signers();
+
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let wait_count = Arc::new(AtomicUsize::new(0));
+
+    let creator = TrackingCreator {
+        inner: MockCreator::<TestTaskData>::new(),
+        get_count: get_count.clone(),
+        wait_count: wait_count.clone(),
+    };
+
+    // Long aggregation timeout so round 2 does not time out before we snapshot counts.
+    let builder = OrchestratorBuilder::new(clock, orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_aggregation_timeout(Duration::from_secs(10));
+
+    let executor = MockExecutor::new();
+    let validator = MockValidator::new_success(1);
+
+    let orchestrator = builder
+        .build(creator, executor, validator)
+        .expect("failed to build orchestrator");
+
+    // MockValidator::new_success(1) always returns Sha256(U256::from(1).abi_encode()).
+    let expected_digest = {
+        let payload = U256::from(1u64).abi_encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        hasher.finalize()
+    };
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+    for contributor_signer in contributor_signers.iter().take(2) {
+        let sig = contributor_signer.sign(None, expected_digest.as_ref());
+        let msg = Aggregation::<TestTaskData>::new(
+            1,
+            TestTaskData::default(),
+            Some(Payload::Signature(sig.to_vec())),
+        );
+        let mut buf = Vec::with_capacity(msg.encode_size());
+        msg.write(&mut buf);
+        msg_tx
+            .send((contributor_signer.public_key(), Bytes::from(buf)))
+            .unwrap();
+    }
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Advance 1 ms — enough to flush the pre-queued channel messages and let execution
+    // fire, but far less than the 10 s aggregation timeout so round 2 has not yet timed
+    // out and triggered another get_payload_and_round call.
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+
+    // get_payload_and_round must have been called exactly once (for round 1).
+    // wait_for_new_round must have been called exactly once (for the round 1 → 2 transition).
+    // If the orchestrator discards the wait_for_new_round result and re-fetches, get_count == 2.
+    assert_eq!(
+        get_count.load(Ordering::SeqCst),
+        1,
+        "get_payload_and_round must not be re-called after execution; \
+         the wait_for_new_round return value must drive the next round"
+    );
+    assert_eq!(
+        wait_count.load(Ordering::SeqCst),
+        1,
+        "wait_for_new_round must be called exactly once after execution"
+    );
+
+    drop(msg_tx);
+    handle.abort();
+}
+
+/// After `wait_for_new_round` returns `Err` the orchestrator must log the error and
+/// retry rather than calling `.unwrap()` and panicking. A panicking orchestrator process
+/// takes the whole service down; for a queue-backed creator an idle queue produces a
+/// timeout error on every inter-round wait, so the panic is not a rare edge case.
+#[tokio::test(start_paused = true)]
+async fn test_orchestrator_survives_wait_for_new_round_error() {
+    use alloy::primitives::U256;
+    use alloy::sol_types::SolValue;
+    use bytes::Bytes;
+    use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
+    use commonware_codec::{EncodeSize, Write};
+    use commonware_cryptography::{Hasher, Sha256, Signer};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map, contributor_signers) =
+        contributor::create_test_contributors_with_signers();
+
+    let creator = ErrorOnceCreator {
+        inner: MockCreator::<TestTaskData>::new(),
+        first_wait: Arc::new(Mutex::new(true)),
+    };
+
+    let builder = OrchestratorBuilder::new(clock, orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_aggregation_timeout(Duration::from_secs(10));
+
+    let executor = MockExecutor::new();
+    let validator = MockValidator::new_success(1);
+
+    let orchestrator = builder
+        .build(creator, executor, validator)
+        .expect("failed to build orchestrator");
+
+    let expected_digest = {
+        let payload = U256::from(1u64).abi_encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        hasher.finalize()
+    };
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+    for contributor_signer in contributor_signers.iter().take(2) {
+        let sig = contributor_signer.sign(None, expected_digest.as_ref());
+        let msg = Aggregation::<TestTaskData>::new(
+            1,
+            TestTaskData::default(),
+            Some(Payload::Signature(sig.to_vec())),
+        );
+        let mut buf = Vec::with_capacity(msg.encode_size());
+        msg.write(&mut buf);
+        msg_tx
+            .send((contributor_signer.public_key(), Bytes::from(buf)))
+            .unwrap();
+    }
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Let execution fire and the first wait_for_new_round (which returns Err) run.
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+
+    // The orchestrator must still be alive — not finished due to an unwrap panic.
+    // With the current .unwrap() the spawned task finishes immediately after the panic.
+    assert!(
+        !handle.is_finished(),
+        "orchestrator must not panic on wait_for_new_round error; \
+         it should log and retry instead of calling .unwrap()"
+    );
 
     drop(msg_tx);
     handle.abort();

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -90,7 +90,7 @@ async fn test_orchestrator_builder_integration() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100))
+        .with_round_timeout(Duration::from_millis(100))
         .with_ingress("127.0.0.1:8080".to_string());
 
     let task_creator = MockCreator::<TestTaskData>::new();
@@ -190,7 +190,7 @@ async fn test_orchestrator_config_integration() {
         .with_contributors(contributors.clone())
         .with_g1_map(g1_map.clone())
         .with_threshold(3)
-        .with_aggregation_timeout(Duration::from_secs(60))
+        .with_round_timeout(Duration::from_secs(60))
         .with_ingress("0.0.0.0:9090".to_string());
 
     let task_creator = MockCreator::<TestTaskData>::new();
@@ -256,7 +256,7 @@ async fn test_orchestrator_environment_integration() {
     unsafe {
         std::env::set_var("INGRESS", "true");
         std::env::set_var("INGRESS_ADDRESS", "127.0.0.1:7070");
-        std::env::set_var("AGGREGATION_TIMEOUT", "120");
+        std::env::set_var("ROUND_TIMEOUT", "120");
         std::env::set_var("THRESHOLD", "2");
     }
 
@@ -286,7 +286,7 @@ async fn test_orchestrator_environment_integration() {
     unsafe {
         std::env::remove_var("INGRESS");
         std::env::remove_var("INGRESS_ADDRESS");
-        std::env::remove_var("AGGREGATION_TIMEOUT");
+        std::env::remove_var("ROUND_TIMEOUT");
         std::env::remove_var("THRESHOLD");
     }
 }
@@ -360,7 +360,7 @@ async fn test_executor_called_exactly_once_after_threshold() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let executor = MockExecutor::new();
     let exec_count = executor.execution_count_handle();
@@ -471,7 +471,7 @@ async fn test_orchestrator_passes_typed_bls_data() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let received = Arc::new(Mutex::new(None));
     let received_round = Arc::new(Mutex::new(None));
@@ -564,7 +564,7 @@ async fn test_metrics_observed_on_quorum_path() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let orchestrator = builder
         .build(
@@ -639,7 +639,7 @@ async fn test_metrics_round_timeout_counted() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_millis(100));
+        .with_round_timeout(Duration::from_millis(100));
 
     let orchestrator = builder
         .build(
@@ -722,7 +722,7 @@ async fn test_get_payload_not_recalled_after_execution() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_secs(10));
+        .with_round_timeout(Duration::from_secs(10));
 
     let executor = MockExecutor::new();
     let validator = MockValidator::new_success(1);
@@ -814,7 +814,7 @@ async fn test_orchestrator_survives_wait_for_new_round_error() {
         .with_contributors(contributors)
         .with_g1_map(g1_map)
         .with_threshold(2)
-        .with_aggregation_timeout(Duration::from_secs(10));
+        .with_round_timeout(Duration::from_secs(10));
 
     let executor = MockExecutor::new();
     let validator = MockValidator::new_success(1);
@@ -862,6 +862,70 @@ async fn test_orchestrator_survives_wait_for_new_round_error() {
         !handle.is_finished(),
         "orchestrator must not panic on wait_for_new_round error; \
          it should log and retry instead of calling .unwrap()"
+    );
+
+    drop(msg_tx);
+    handle.abort();
+}
+
+/// A `rebroadcast_interval` shorter than `round_timeout` causes `Start` to be re-sent
+/// within the same round.  The rebroadcast count increments independently of timeouts;
+/// the round does not start over (rounds_started stays 1) and no timeout fires.
+#[tokio::test(start_paused = true)]
+async fn test_rebroadcast_fires_before_round_timeout() {
+    use bytes::Bytes;
+    use commonware_runtime::Metrics;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map) = contributor::create_test_contributors();
+
+    let builder = OrchestratorBuilder::new(clock.clone(), orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_round_timeout(Duration::from_millis(300))
+        .with_rebroadcast_interval(Duration::from_millis(100));
+
+    let orchestrator = builder
+        .build(
+            MockCreator::<TestTaskData>::new(),
+            MockExecutor::new(),
+            MockValidator::new_success(1),
+        )
+        .expect("failed to build orchestrator");
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Let the orchestrator register its timers, then advance past the first
+    // rebroadcast_interval (100ms) but well short of round_timeout (300ms).
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(100)).await;
+    tokio::task::yield_now().await;
+
+    let encoded = clock.encode();
+
+    // The initial broadcast plus one rebroadcast within the same round.
+    assert!(
+        encoded.contains("orchestrator_round_broadcasts_total 2"),
+        "expected two broadcasts (initial + rebroadcast) but got:\n{encoded}"
+    );
+    // The round has not timed out — still on round 1.
+    assert!(
+        encoded.contains("orchestrator_rounds_started_total 1"),
+        "expected round 1 to still be open but got:\n{encoded}"
+    );
+    // No timeout has fired.
+    assert!(
+        !encoded.contains("orchestrator_round_timeouts_total 1"),
+        "expected no timeout yet but got:\n{encoded}"
     );
 
     drop(msg_tx);

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -687,6 +687,78 @@ async fn test_metrics_round_timeout_counted() {
     handle.abort();
 }
 
+/// With a short `round_timeout` and a long `rebroadcast_interval`, the orchestrator
+/// abandons rounds quickly without amplifying `Start` broadcasts.  Each round produces
+/// exactly one broadcast (the initial one); the rebroadcast timer never fires within
+/// any round because `rebroadcast_interval >> round_timeout`.
+///
+/// This is the core safety property of the decoupled knobs: operators can shrink
+/// `round_timeout` for fast recovery without flooding the P2P channel with `Start`
+/// messages.
+#[tokio::test(start_paused = true)]
+async fn test_short_round_timeout_no_rebroadcast_storm() {
+    use bytes::Bytes;
+    use commonware_runtime::Metrics;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map) = contributor::create_test_contributors();
+
+    // round_timeout=100ms, rebroadcast_interval=10s: the rebroadcast timer never
+    // fires during any round because the round times out first.
+    let builder = OrchestratorBuilder::new(clock.clone(), orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_round_timeout(Duration::from_millis(100))
+        .with_rebroadcast_interval(Duration::from_secs(10));
+
+    let orchestrator = builder
+        .build(
+            MockCreator::<TestTaskData>::new(),
+            MockExecutor::new(),
+            MockValidator::new_success(1),
+        )
+        .expect("failed to build orchestrator");
+
+    let (msg_tx, msg_rx) = unbounded_channel::<(commonware_avs_core::bn254::PublicKey, Bytes)>();
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Each round's timer is registered as tokio::time::sleep(100ms) from the moment
+    // MockClock::sleep_until is called, so it fires 100ms of tokio-time after that
+    // call — not at a fixed absolute offset. To drive N timeouts we must interleave
+    // yield (let the task register the next timer) and advance (fire it).
+    tokio::task::yield_now().await; // round 1 starts, registers sleep(100ms)
+    for _ in 0..3 {
+        tokio::time::advance(Duration::from_millis(100)).await; // fire current round's timer
+        tokio::task::yield_now().await; // process timeout, start next round
+    }
+
+    let encoded = clock.encode();
+
+    // 3 timeouts, 4 rounds started (round 4 open), 4 broadcasts.
+    // broadcasts_total == rounds_started proves exactly one Start per round: no storm.
+    for expected in [
+        "orchestrator_round_timeouts_total 3",
+        "orchestrator_rounds_started_total 4",
+        "orchestrator_round_broadcasts_total 4",
+    ] {
+        assert!(
+            encoded.contains(expected),
+            "expected `{expected}` in encoded metrics:\n{encoded}"
+        );
+    }
+
+    drop(msg_tx);
+    handle.abort();
+}
+
 /// After a successful execution the orchestrator must use the `(payload, round)` returned by
 /// `wait_for_new_round` directly for the next broadcast rather than discarding that result and
 /// calling `get_payload_and_round` a second time. Calling `get_payload_and_round` an extra

--- a/router/src/orchestrator/tests/integration.rs
+++ b/router/src/orchestrator/tests/integration.rs
@@ -1003,3 +1003,91 @@ async fn test_rebroadcast_fires_before_round_timeout() {
     drop(msg_tx);
     handle.abort();
 }
+
+/// Verifies that a `DurationProvider` that changes its return value between rounds causes
+/// the orchestrator to apply the new timeout on the next round.
+///
+/// Setup: the provider starts at 300 ms. After the first round times out we bump it to
+/// 100 ms. We then confirm that the second round fires a timeout within 100 ms (not 300 ms),
+/// which would only be possible if `round_timeout` was sampled at the start of each round.
+#[tokio::test(start_paused = true)]
+async fn test_dynamic_round_timeout_provider() {
+    use commonware_runtime::Metrics;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    let clock = MockClock::new();
+    let orchestrator_signer = signer::create_test_signer();
+    let (contributors, g1_map) = contributor::create_test_contributors();
+
+    // Shared atomic millisecond value — starts at 300 ms, will be lowered to 100 ms.
+    let timeout_ms = Arc::new(AtomicU64::new(300));
+    let timeout_ms_clone = timeout_ms.clone();
+    let provider: crate::orchestrator::types::DurationProvider =
+        Arc::new(move || Duration::from_millis(timeout_ms_clone.load(Ordering::Relaxed)));
+
+    let builder = OrchestratorBuilder::new(clock.clone(), orchestrator_signer)
+        .with_contributors(contributors)
+        .with_g1_map(g1_map)
+        .with_threshold(2)
+        .with_round_timeout_provider(provider)
+        .with_rebroadcast_interval(Duration::from_secs(3600)); // effectively disabled
+
+    let orchestrator = builder
+        .build(
+            MockCreator::<TestTaskData>::new(),
+            MockExecutor::new(),
+            MockValidator::new_success(1),
+        )
+        .expect("failed to build orchestrator");
+
+    let (msg_tx, msg_rx) = tokio::sync::mpsc::unbounded_channel::<(
+        commonware_avs_core::bn254::PublicKey,
+        bytes::Bytes,
+    )>();
+
+    let handle = tokio::spawn(async move {
+        orchestrator
+            .run(MockSender::new(), MockReceiver::new(msg_rx))
+            .await;
+    });
+
+    // Yield so the orchestrator starts and registers the first round timer at 300 ms.
+    tokio::task::yield_now().await;
+
+    // Change the provider to 100 ms while round 1 is still running. Round 2 will pick
+    // this up when it calls the provider at the start of the new round.
+    timeout_ms.store(100, Ordering::Relaxed);
+
+    // Advance past the first 300 ms timeout — round 1 times out, round 2 starts and
+    // registers a new timer using the updated provider value (100 ms from now).
+    tokio::time::advance(Duration::from_millis(300)).await;
+    tokio::task::yield_now().await;
+
+    let encoded = clock.encode();
+    assert!(
+        encoded.contains("orchestrator_round_timeouts_total 1"),
+        "expected one timeout after 300 ms but got:\n{encoded}"
+    );
+    assert!(
+        encoded.contains("orchestrator_rounds_started_total 2"),
+        "expected round 2 to have started but got:\n{encoded}"
+    );
+
+    // Advance only 100 ms — only sufficient if round 2 used the updated provider (100 ms),
+    // not the stale value (300 ms). Proves the provider is sampled fresh each round.
+    tokio::time::advance(Duration::from_millis(100)).await;
+    tokio::task::yield_now().await;
+
+    let encoded = clock.encode();
+    assert!(
+        encoded.contains("orchestrator_round_timeouts_total 2"),
+        "expected two timeouts — proves provider is sampled each round, but got:\n{encoded}"
+    );
+    assert!(
+        encoded.contains("orchestrator_rounds_started_total 3"),
+        "expected round 3 to have started but got:\n{encoded}"
+    );
+
+    drop(msg_tx);
+    handle.abort();
+}

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -226,7 +226,8 @@ where
             let round_timeout_deadline = self.runtime.current() + self.round_timeout;
             let mut executed_round: Option<u64> = None;
             let mut rebroadcast_fut = std::pin::pin!(
-                self.runtime.sleep_until(self.runtime.current() + self.rebroadcast_interval)
+                self.runtime
+                    .sleep_until(self.runtime.current() + self.rebroadcast_interval)
             );
             loop {
                 tokio::select! {

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -24,13 +24,26 @@ use crate::executor::{FromBlsAggregation, VerificationData, VerificationExecutor
 use crate::orchestrator::metrics::OrchestratorMetrics;
 use crate::orchestrator::traits::OrchestratorTrait;
 
+/// A callable that returns a `Duration`, sampled once per round on the hot path.
+///
+/// Use `constant_duration` for a fixed value, or wrap a shared atomic/`RwLock` to
+/// allow an adaptive controller to adjust the orchestrator's timing live.
+pub type DurationProvider = std::sync::Arc<dyn Fn() -> Duration + Send + Sync>;
+
+/// Returns a `DurationProvider` that always yields `d`.
+pub fn constant_duration(d: Duration) -> DurationProvider {
+    std::sync::Arc::new(move || d)
+}
+
 /// Configuration for the generic orchestrator
-#[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    /// Max duration to wait for operator signatures before abandoning a round.
-    pub round_timeout: Duration,
-    /// How often to re-send the `Start` broadcast for an in-flight round.
-    pub rebroadcast_interval: Duration,
+    /// Called once per round to determine how long to wait for threshold signatures
+    /// before abandoning the round. A dynamic provider lets an adaptive controller
+    /// shrink or grow this window at runtime.
+    pub round_timeout: DurationProvider,
+    /// Called once per round (and again after each rebroadcast) to determine the
+    /// interval between `Start` re-sends for an in-flight round.
+    pub rebroadcast_interval: DurationProvider,
     pub contributors: Vec<PublicKey>,
     pub g1_map: HashMap<PublicKey, G1PublicKey>,
     pub threshold: usize,
@@ -60,8 +73,8 @@ where
     runtime: C,
     #[allow(dead_code)]
     signer: Bn254,
-    round_timeout: Duration,
-    rebroadcast_interval: Duration,
+    round_timeout: DurationProvider,
+    rebroadcast_interval: DurationProvider,
     contributors: Vec<PublicKey>,
     g1_map: HashMap<PublicKey, G1PublicKey>, // g2 (PublicKey) -> g1 (PublicKey)
     ordered_contributors: HashMap<PublicKey, usize>,
@@ -124,8 +137,8 @@ where
         Self {
             runtime,
             signer,
-            round_timeout: config.round_timeout,
-            rebroadcast_interval: config.rebroadcast_interval,
+            round_timeout: config.round_timeout.clone(),
+            rebroadcast_interval: config.rebroadcast_interval.clone(),
             contributors,
             g1_map: config.g1_map,
             ordered_contributors,
@@ -223,11 +236,11 @@ where
             // biased: round_timeout is checked first so it wins when both it and the
             // rebroadcast timer fire simultaneously (round_timeout == rebroadcast_interval),
             // preserving the original single-knob behaviour.
-            let round_timeout_deadline = self.runtime.current() + self.round_timeout;
+            let round_timeout_deadline = self.runtime.current() + (self.round_timeout)();
             let mut executed_round: Option<u64> = None;
             let mut rebroadcast_fut = std::pin::pin!(
                 self.runtime
-                    .sleep_until(self.runtime.current() + self.rebroadcast_interval)
+                    .sleep_until(self.runtime.current() + (self.rebroadcast_interval)())
             );
             loop {
                 tokio::select! {
@@ -252,7 +265,7 @@ where
                         self.metrics.round_broadcasts.inc();
                         rebroadcast_fut.set(
                             self.runtime
-                                .sleep_until(self.runtime.current() + self.rebroadcast_interval),
+                                .sleep_until(self.runtime.current() + (self.rebroadcast_interval)()),
                         );
                     },
                     msg = receiver.recv() => {

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -183,6 +183,9 @@ where
                     Ok(val) => val,
                     Err(e) => {
                         tracing::error!("get_payload_and_round failed: {e}");
+                        self.runtime
+                            .sleep_until(self.runtime.current() + WAIT_RETRY_BACKOFF)
+                            .await;
                         continue;
                     }
                 },

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -150,9 +150,22 @@ where
         mut receiver: impl Receiver<PublicKey = PublicKey>,
     ) {
         let mut signatures: HashMap<u64, RoundState> = HashMap::new();
+        // Carries the (payload, round) returned by wait_for_new_round after a successful
+        // execution so the outer loop can use it directly without an extra get_payload_and_round
+        // call. None on the first iteration and after every aggregation timeout.
+        let mut cached_round: Option<(Vec<u8>, u64)> = None;
 
         loop {
-            let (payload, current_round) = self.task_creator.get_payload_and_round().await.unwrap();
+            let (payload, current_round) = match cached_round.take() {
+                Some(val) => val,
+                None => match self.task_creator.get_payload_and_round().await {
+                    Ok(val) => val,
+                    Err(e) => {
+                        tracing::error!("get_payload_and_round failed: {e}");
+                        continue;
+                    }
+                },
+            };
 
             // Create a new hasher for each iteration
             let mut hasher = Sha256::new();
@@ -195,6 +208,7 @@ where
 
             // Listen for messages until the next broadcast
             let continue_time = self.runtime.current() + self.aggregation_timeout;
+            let mut executed_round: Option<u64> = None;
             loop {
                 select! {
                     _ = self.runtime.sleep_until(continue_time) => {
@@ -343,9 +357,7 @@ where
                                 );
                                 self.metrics.round_executions.inc(Status::Success);
                                 signatures.remove(&msg.round);
-                                // Block until on-chain state advances to the next round so the outer
-                                // loop broadcasts a fresh round immediately on return.
-                                self.task_creator.wait_for_new_round(msg.round).await.unwrap();
+                                executed_round = Some(msg.round);
                                 break;
                             },
                             Err(e) => {
@@ -361,6 +373,37 @@ where
                         }
                     },
                 }
+            }
+
+            // After the inner loop exits: if execution succeeded, wait until the on-chain
+            // round advances before broadcasting again. The receiver is drained concurrently
+            // to prevent P2P buffer build-up during the inter-round wait. Transient errors
+            // from wait_for_new_round (e.g. a queue-backed creator timing out between tasks)
+            // are logged and retried rather than panicking.
+            if let Some(ex_round) = executed_round {
+                let mut wait_fut = std::pin::pin!(self.task_creator.wait_for_new_round(ex_round));
+                cached_round = Some(loop {
+                    tokio::select! {
+                        biased;
+                        result = &mut wait_fut => {
+                            match result {
+                                Ok(val) => break val,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        round = ex_round,
+                                        "wait_for_new_round error: {e}; retrying"
+                                    );
+                                    wait_fut.set(
+                                        self.task_creator.wait_for_new_round(ex_round)
+                                    );
+                                }
+                            }
+                        },
+                        received = receiver.recv() => {
+                            let _ = received;
+                        }
+                    }
+                });
             }
         }
     }

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -7,7 +7,6 @@ use commonware_avs_core::validator::ValidatorTrait;
 use commonware_avs_core::wire::{Aggregation, aggregation::Payload};
 use commonware_codec::{EncodeSize, ReadExt, Write};
 use commonware_cryptography::{Hasher, Sha256, Verifier};
-use commonware_macros::select;
 use commonware_p2p::{Receiver, Sender};
 use commonware_runtime::telemetry::metrics::histogram::HistogramExt;
 use commonware_runtime::telemetry::metrics::status::{CounterExt, Status};
@@ -28,7 +27,10 @@ use crate::orchestrator::traits::OrchestratorTrait;
 /// Configuration for the generic orchestrator
 #[derive(Debug, Clone)]
 pub struct OrchestratorConfig {
-    pub aggregation_timeout: Duration,
+    /// Max duration to wait for operator signatures before abandoning a round.
+    pub round_timeout: Duration,
+    /// How often to re-send the `Start` broadcast for an in-flight round.
+    pub rebroadcast_interval: Duration,
     pub contributors: Vec<PublicKey>,
     pub g1_map: HashMap<PublicKey, G1PublicKey>,
     pub threshold: usize,
@@ -58,7 +60,8 @@ where
     runtime: C,
     #[allow(dead_code)]
     signer: Bn254,
-    aggregation_timeout: Duration,
+    round_timeout: Duration,
+    rebroadcast_interval: Duration,
     contributors: Vec<PublicKey>,
     g1_map: HashMap<PublicKey, G1PublicKey>, // g2 (PublicKey) -> g1 (PublicKey)
     ordered_contributors: HashMap<PublicKey, usize>,
@@ -121,7 +124,8 @@ where
         Self {
             runtime,
             signer,
-            aggregation_timeout: config.aggregation_timeout,
+            round_timeout: config.round_timeout,
+            rebroadcast_interval: config.rebroadcast_interval,
             contributors,
             g1_map: config.g1_map,
             ordered_contributors,
@@ -210,14 +214,45 @@ where
                 Entry::Occupied(_) => {}
             }
 
-            // Listen for messages until the next broadcast
-            let continue_time = self.runtime.current() + self.aggregation_timeout;
+            // Collect signatures until the round times out or reaches the threshold.
+            // The rebroadcast timer re-sends `Start` for the same round on a shorter
+            // cadence so nodes that missed the first broadcast can still sign; it is
+            // independent of round_timeout so operators can set a fast recovery window
+            // without flooding the network with Start messages.
+            //
+            // biased: round_timeout is checked first so it wins when both it and the
+            // rebroadcast timer fire simultaneously (round_timeout == rebroadcast_interval),
+            // preserving the original single-knob behaviour.
+            let round_timeout_deadline = self.runtime.current() + self.round_timeout;
             let mut executed_round: Option<u64> = None;
+            let mut rebroadcast_fut = std::pin::pin!(
+                self.runtime.sleep_until(self.runtime.current() + self.rebroadcast_interval)
+            );
             loop {
-                select! {
-                    _ = self.runtime.sleep_until(continue_time) => {
+                tokio::select! {
+                    biased;
+                    _ = self.runtime.sleep_until(round_timeout_deadline) => {
                         self.metrics.round_timeouts.inc();
                         break;
+                    },
+                    _ = &mut rebroadcast_fut => {
+                        let task_data = self.task_creator.get_task_metadata();
+                        let rebroadcast_msg = Aggregation::<TC::TaskData>::new(
+                            current_round,
+                            task_data,
+                            Some(Payload::Start),
+                        );
+                        let mut buf = Vec::with_capacity(rebroadcast_msg.encode_size());
+                        rebroadcast_msg.write(&mut buf);
+                        sender
+                            .send(commonware_p2p::Recipients::All, Bytes::from(buf), true)
+                            .await
+                            .expect("failed to rebroadcast Start");
+                        self.metrics.round_broadcasts.inc();
+                        rebroadcast_fut.set(
+                            self.runtime
+                                .sleep_until(self.runtime.current() + self.rebroadcast_interval),
+                        );
                     },
                     msg = receiver.recv() => {
                         // Parse message

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -14,7 +14,7 @@ use commonware_runtime::telemetry::metrics::status::{CounterExt, Status};
 use commonware_runtime::{Clock, Metrics};
 use commonware_utils::hex;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     marker::PhantomData,
     time::{Duration, SystemTime},
 };
@@ -150,7 +150,6 @@ where
         mut receiver: impl Receiver<PublicKey = PublicKey>,
     ) {
         let mut signatures: HashMap<u64, RoundState> = HashMap::new();
-        let mut executed_rounds: HashSet<u64> = HashSet::new();
 
         loop {
             let (payload, current_round) = self.task_creator.get_payload_and_round().await.unwrap();
@@ -164,18 +163,6 @@ where
                 msg = hex(&payload),
                 "generated payload for state"
             );
-
-            // Skip broadcasting for already-executed rounds, but keep servicing the receiver
-            // so late signatures/messages for completed rounds do not build up in the buffer.
-            if executed_rounds.contains(&current_round) {
-                select! {
-                    _ = self.runtime.sleep(Duration::from_secs(2)) => {},
-                    received = receiver.recv() => {
-                        let _ = received;
-                    },
-                }
-                continue;
-            }
 
             // Broadcast payload
             let task_data = self.task_creator.get_task_metadata();
@@ -234,11 +221,6 @@ where
                             self.metrics.signatures.inc(Status::Invalid);
                             continue;
                         };
-                        if executed_rounds.contains(&msg.round) {
-                            info!("Ignoring signature for already-executed round: {} from contributor: {:?}", msg.round, contributor);
-                            self.metrics.signatures.inc(Status::Dropped);
-                            continue;
-                        }
                         let Some(round) = signatures.get_mut(&msg.round) else {
                             info!("Received signature for unknown round: {} from contributor: {:?}", msg.round, contributor);
                             self.metrics.signatures.inc(Status::Dropped);
@@ -360,20 +342,10 @@ where
                                     result
                                 );
                                 self.metrics.round_executions.inc(Status::Success);
-                                // Drop per-round signature state now that this round has finished.
                                 signatures.remove(&msg.round);
-                                // Mark round complete so additional signatures are ignored and the outer
-                                // loop does not re-broadcast Start while waiting for on-chain state to advance.
-                                //
-                                // Rounds advance monotonically, so only the latest executed round needs to
-                                // be retained to suppress duplicate processing without unbounded growth.
-                                executed_rounds.clear();
-                                executed_rounds.insert(msg.round);
-                                // Return to the outer loop immediately so the next queued task is
-                                // fetched without waiting out `aggregation_timeout`. If a chain-polling
-                                // creator re-returns this same round, the `executed_rounds` branch at the
-                                // top of the outer loop avoids re-broadcasting Start (sleeping up to 2s
-                                // when idle while still draining the receiver to prevent buffer build-up).
+                                // Block until on-chain state advances to the next round so the outer
+                                // loop broadcasts a fresh round immediately on return.
+                                self.task_creator.wait_for_new_round(msg.round).await.unwrap();
                                 break;
                             },
                             Err(e) => {

--- a/router/src/orchestrator/types.rs
+++ b/router/src/orchestrator/types.rs
@@ -149,6 +149,10 @@ where
         mut sender: impl Sender,
         mut receiver: impl Receiver<PublicKey = PublicKey>,
     ) {
+        // Backoff between wait_for_new_round retries; bounds hot-spinning when a creator
+        // fails immediately (e.g. CounterCreator when the provider is temporarily down).
+        const WAIT_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+
         let mut signatures: HashMap<u64, RoundState> = HashMap::new();
         // Carries the (payload, round) returned by wait_for_new_round after a successful
         // execution so the outer loop can use it directly without an extra get_payload_and_round
@@ -393,6 +397,11 @@ where
                                         round = ex_round,
                                         "wait_for_new_round error: {e}; retrying"
                                     );
+                                    self.runtime
+                                        .sleep_until(
+                                            self.runtime.current() + WAIT_RETRY_BACKOFF,
+                                        )
+                                        .await;
                                     wait_fut.set(
                                         self.task_creator.wait_for_new_round(ex_round)
                                     );


### PR DESCRIPTION
Bundles three orchestrator improvements that were each reviewed and merged individually into `bagelface/orchestrator-refactor` before landing here.

## Changes

### #153 — Replace polling loop with `wait_for_new_round`

Previously the orchestrator called `get_payload_and_round` in a tight loop (with a 2 s sleep) after each execution, waiting for on-chain state to advance. This required a `HashSet<u64>` of executed rounds to suppress duplicate `Start` broadcasts.

- Adds `wait_for_new_round(current: u64) -> Result<(Vec<u8>, u64)>` to the `Creator` trait; the orchestrator blocks on it instead of polling
- Removes the `HashSet<u64>` and the associated duplicate-broadcast guard
- Drains the P2P receiver concurrently during the inter-round wait to prevent buffer build-up
- Adds a 1 s backoff when `wait_for_new_round` returns `Err`, bounding the retry rate for queue-backed creators that time out between tasks

### #164 — Decouple `round_timeout` from `rebroadcast_interval`

Previously a single `aggregation_timeout` conflated two concerns: how long to wait for threshold signatures, and how often to re-send the `Start` broadcast mid-round.

- Replaces the single knob with independent `round_timeout` and `rebroadcast_interval` fields
- Inner loop becomes a three-branch `biased` `tokio::select!`: round timeout is checked first so it wins when both timers fire simultaneously (i.e. when the two values are equal, preserving the original single-knob behaviour)
- A short `rebroadcast_interval` lets dropped `Start` messages be recovered without forcing an early round timeout
- Breaking change: `with_aggregation_timeout` removed; callers use `with_round_timeout` / `with_rebroadcast_interval`; env vars renamed to `ROUND_TIMEOUT` / `REBROADCAST_INTERVAL`

### #165 — `DurationProvider` for runtime-adaptive timing

- Changes both timer fields from static `Duration` to `DurationProvider = Arc<dyn Fn() -> Duration + Send + Sync>`, sampled once per round and once per rebroadcast reset
- `constant_duration(d)` wraps a fixed value for the common case
- Adds `with_round_timeout_provider` / `with_rebroadcast_interval_provider` builder methods for callers that need live control (e.g. an adapter reading chain conditions or a config hot-reload path)
- Implements `Debug` manually for `OrchestratorConfig`, sampling current values at display time

## Test coverage

- `test_short_round_timeout_no_rebroadcast_storm` — short timeout + long rebroadcast interval produces exactly one broadcast per round
- `test_rebroadcast_fires_before_round_timeout` — rebroadcast fires mid-round without advancing the round counter
- `test_orchestrator_survives_wait_for_new_round_error` — `Err` from `wait_for_new_round` is handled gracefully; no panic
- `test_get_payload_not_recalled_after_execution` — `get_payload_and_round` is called exactly once per round; the `wait_for_new_round` return value drives the next round directly
- `test_dynamic_round_timeout_provider` — updating the provider mid-run causes the next round to use the new timeout value