### PR TITLE
feat: make inter-round poll interval configurable via POLLING_INTERVAL_MS

### DIFF
--- a/example.env
+++ b/example.env
@@ -94,6 +94,9 @@ SIGNER_ENDPOINT=http://signer:50051
 # =============================================================================
 INGRESS=false
 
+# How often (in milliseconds) to poll for a new round between task cycles.
+POLLING_INTERVAL_MS=2000
+
 # Max seconds to wait for threshold signatures before abandoning a round (supports fractional)
 ROUND_TIMEOUT=30
 

--- a/examples/counter/router/src/creator.rs
+++ b/examples/counter/router/src/creator.rs
@@ -14,12 +14,14 @@ use serde::{Deserialize, Serialize};
 
 pub struct CounterCreator {
     provider: Arc<CounterProvider>,
+    polling_interval: Duration,
 }
 
 impl CounterCreator {
-    pub fn new(provider: CounterProvider) -> Self {
+    pub fn new(provider: CounterProvider, polling_interval: Duration) -> Self {
         Self {
             provider: Arc::new(provider),
+            polling_interval,
         }
     }
 }
@@ -41,7 +43,7 @@ impl Creator for CounterCreator {
                 let payload = self.provider.encode_round(round);
                 return Ok((payload, round));
             }
-            sleep(Duration::from_secs(2)).await;
+            sleep(self.polling_interval).await;
         }
     }
 

--- a/examples/counter/router/src/factories.rs
+++ b/examples/counter/router/src/factories.rs
@@ -12,7 +12,7 @@ use commonware_avs_router::creator::{CreatorConfig, SimpleTaskQueue};
 use commonware_avs_router::ingress::http_server::start_http_server;
 use counter_bindings::Counter;
 use counter_common::config::CounterDeployment;
-use std::{env, str::FromStr};
+use std::{env, str::FromStr, time::Duration};
 
 pub async fn create_creator() -> Result<CounterCreatorType> {
     let http_rpc = env::var("HTTP_RPC").expect("HTTP_RPC must be set");
@@ -31,8 +31,12 @@ pub async fn create_creator() -> Result<CounterCreatorType> {
         .counter_address()
         .map_err(|e| anyhow::anyhow!("Failed to get counter address: {}", e))?;
 
+    let polling_interval_ms: u64 = env::var("POLLING_INTERVAL_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2_000);
     let provider = CounterProvider::new(counter_address, provider.clone());
-    let creator = CounterCreator::new(provider);
+    let creator = CounterCreator::new(provider, Duration::from_millis(polling_interval_ms));
     Ok(CounterCreatorType::Basic(creator))
 }
 


### PR DESCRIPTION
Closes #176

## Summary
- Adds a `polling_interval: Duration` field to `CounterCreator`, replacing the hardcoded 2-second sleep in `wait_for_new_round`
- Wires the value through `CounterCreator::new`, read from `POLLING_INTERVAL_MS` env var (default: 2000ms)
- Documents `POLLING_INTERVAL_MS` in `example.env`

## Test plan
- [ ] Existing behaviour unchanged when `POLLING_INTERVAL_MS` is unset (defaults to 2000ms)
- [ ] Setting `POLLING_INTERVAL_MS` to a different value changes the poll cadence