### PR TITLE
feat: pluggable signature schemes — generic chassis, ECDSA scheme, certificate taps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,9 @@ name = "commonware-avs-core"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
  "anyhow",
  "ark-bn254",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,6 +2074,7 @@ dependencies = [
  "commonware-cryptography",
  "commonware-macros",
  "commonware-p2p",
+ "commonware-parallel",
  "commonware-runtime",
  "commonware-utils",
  "dotenv",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monorepo for the Commonware AVS reference implementation on EigenLayer. It contains:
 
-- [`core`](./core): Core protocol types — BN254 certificate scheme for the commonware-consensus aggregation engine, validators, wire formats, and utility code
+- [`core`](./core): Core protocol types — BN254 and ECDSA (secp256k1) certificate schemes for the commonware-consensus aggregation engine, validators, wire formats, and utility code
 - [`bindings`](./bindings): Standalone crate for on-chain contract bindings
 - [`router`](./router): Generic library for running the aggregation router: task sequencer, verifier-only aggregation engine, and on-chain certificate submitter
 - [`node`](./node): Generic library for running an operator node: aggregation-engine participant actors (task book, automaton, reporter)
@@ -25,14 +25,38 @@ Tasks flow through a fixed operator set as a sequence of *aggregation heights*:
    against its own view of the world (the application's `ValidatorTrait`
    implementation) and signs the expected task digest — or the skip digest for an
    abandoned height. Signatures travel as acks on channel 0, gossiped by the
-   commonware-consensus aggregation engine running a BN254 multisig certificate
+   commonware-consensus aggregation engine running the deployment's certificate
    scheme.
 3. **The router certifies and submits.** The router runs the same engine
-   verifier-only: it validates acks and assembles a certificate (signer bitmap +
-   aggregated signature) once quorum is reached. The submitter maps the bitmap to
-   registered operator addresses via `BLSApkRegistry`, fetches
-   `NonSignerStakesAndSignature`, and hands both to the application's handler for
-   the on-chain BLS verification call.
+   verifier-only: it validates acks and assembles a certificate once quorum is
+   reached. A scheme-specific submitter resolves the certificate into on-chain
+   calldata and hands it to the application's handler for the verification call.
+
+### Signature schemes
+
+The actor chassis (sequencer, task book, automatons, reporters) is generic over
+`commonware_cryptography::certificate::Scheme` and the p2p identity type, so a
+deployment picks its scheme at wiring time. Two single-shot schemes ship in
+[`core`](./core):
+
+- **BN254 multisig** (`core::bn254`): the G2 operator key doubles as the p2p
+  identity; certificates carry one aggregated G1 signature. The
+  [`Submitter`](./router/src/submitter.rs) resolves signers through
+  `BLSApkRegistry` and fetches `NonSignerStakesAndSignature` for on-chain BLS
+  verification.
+- **ECDSA secp256k1** (`core::ecdsa`): the operator's Ethereum key is both the
+  p2p identity (20-byte address) and the signing key; certificates carry one
+  65-byte signature per signer in participant order. The
+  [`EcdsaSubmitter`](./router/src/ecdsa_submitter.rs) hands
+  `(operators[], signatures[])` to the application's handler (e.g. an ERC-1271
+  stake-registry check).
+
+Schemes with needs beyond single-shot signing (extra protocol rounds, nonce
+management, side storage) live in the application, plugged in through the same
+seams the built-in schemes use: implement `certificate::Scheme` for the engine,
+`CertIndex` to drive the shared sequencer, and consume certificates generically —
+router-side via the `CertifiedHeight<S>` channel, node-side via the reporter's
+opt-in `CertificateObservation<S>` tap (`NodeReporter::with_certificate_tap`).
 
 Quorum is engine-fixed at N3f1 — `n − ⌊(n−1)/3⌋` of `n` operators (3-of-3 at n=3,
 3-of-4 at n=4). Deployments should run n ≥ 4 in production so a single unavailable

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,8 @@ test-utils = []
 
 [dependencies]
 alloy = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-signer = { workspace = true }
 anyhow = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
@@ -29,6 +31,7 @@ rand = { workspace = true }
 rand_core = { workspace = true }
 
 [dev-dependencies]
+alloy-signer-local = { workspace = true }
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/core/src/ecdsa/mod.rs
+++ b/core/src/ecdsa/mod.rs
@@ -1,0 +1,844 @@
+//! secp256k1 ECDSA key types and Ethereum-compatible signing.
+//!
+//! A second engine-compatible certificate scheme alongside [`crate::bn254`], for
+//! deployments whose on-chain verifier checks signatures via Ethereum's
+//! `ecrecover` rather than a BLS pairing. The cryptographic contract with the
+//! chain is:
+//!
+//! - Signing produces a 65-byte `r || s || v` signature (low-s per EIP-2, `v` in
+//!   Electrum notation 27/28) over a 32-byte digest used AS-IS (no EIP-191 prefix,
+//!   no extra hashing). This is exactly the byte layout an on-chain verifier
+//!   recovers with `ecrecover(msgHash, v, r, s)`.
+//! - Verification is recovery-based: recover the signer address from the signature
+//!   and compare it with the expected address. This is what lets a 20-byte
+//!   Ethereum address serve as the [`PublicKey`] type — the same address the
+//!   operator registered with EigenLayer.
+//! - Namespace semantics (see [`signing_payload`]): a `None` namespace with an
+//!   exactly 32-byte message means "the message IS the digest" and is signed raw —
+//!   this is the on-chain path. Any other input is hashed (with `union_unique`
+//!   domain separation when a namespace is present) — this is the path the
+//!   2026.5.0 `Signer`/`Verifier` traits use (the p2p handshake always provides a
+//!   namespace).
+//!
+//! Type surface:
+//! - [`PrivateKey`]: the secp256k1 scalar (32 bytes, big-endian).
+//! - [`Ecdsa`]: the signer (implements the 2026.5.0 [`commonware_cryptography::Signer`]
+//!   trait, so it can be the p2p identity signer for `authenticated::lookup`).
+//! - [`PublicKey`]: the signer's Ethereum address (20 bytes). The operator's
+//!   registered EigenLayer address, the p2p identity, AND the participant identity
+//!   key ordering the certificate scheme's participant set.
+//! - [`Signature`]: 65 bytes `r || s || v` with `v` in {27, 28}. Decoding rejects
+//!   non-canonical encodings (zero `r`/`s`, high-s, bad parity byte) so signature
+//!   bytes are unique per (digest, key) and byte-comparison equality is sound.
+
+pub mod scheme;
+
+pub use scheme::{EcdsaCertificate, EcdsaScheme};
+
+use alloy_primitives::{Address, B256, U256};
+use alloy_signer::k256::ecdsa::SigningKey;
+use alloy_signer::utils::secret_key_to_address;
+use bytes::{Buf, BufMut};
+use commonware_codec::{Error, FixedSize, Read, Write};
+use commonware_cryptography::{
+    Hasher as _, PublicKey as CPublicKey, Sha256, Signature as CSignature, Signer, Verifier,
+};
+use commonware_math::algebra::Random;
+use commonware_utils::{Array, Span, union_unique};
+use rand_core::CryptoRngCore;
+use std::borrow::Cow;
+use std::fmt::{self, Debug, Display};
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+
+/// Formats raw key/signature bytes as lowercase hex — the shared `Debug`/`Display`
+/// body for the (non-secret) types.
+fn fmt_hex(raw: &[u8], f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "0x{}", hex::encode(raw))
+}
+
+/// Length of a signing digest in bytes.
+const DIGEST_LENGTH: usize = 32;
+/// Length of a [`PrivateKey`] (secp256k1 scalar, big-endian) in bytes.
+const PRIVATE_KEY_LENGTH: usize = 32;
+/// Length of a [`PublicKey`] (Ethereum address) in bytes.
+const PUBLIC_KEY_LENGTH: usize = 20;
+/// Length of a [`Signature`] (`r || s || v`) in bytes.
+const SIGNATURE_LENGTH: usize = 65;
+
+/// secp256k1 group order / 2
+/// (`0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0`).
+/// Signatures with `s` above this are malleable (EIP-2) and rejected at the
+/// decode boundary.
+const HALF_CURVE_ORDER: U256 = U256::from_limbs([
+    0xdfe92f46681b20a0,
+    0x5d576e7357a4501d,
+    0xffffffffffffffff,
+    0x7fffffffffffffff,
+]);
+
+/// Computes the 32-byte digest that gets signed/recovered.
+///
+/// INVARIANT (on-chain compatibility): `namespace == None` and a 32-byte message
+/// means the message is a pre-hashed digest and is used as-is — this is the path
+/// whose signatures `ecrecover` validates on-chain. Every other combination is
+/// hashed: `sha256(union_unique(namespace, message))` when a namespace is present
+/// (the p2p handshake path), `sha256(message)` otherwise.
+fn signing_payload(namespace: Option<&[u8]>, message: &[u8]) -> [u8; DIGEST_LENGTH] {
+    if namespace.is_none() && message.len() == DIGEST_LENGTH {
+        return message.try_into().expect("length checked above");
+    }
+    let payload = match namespace {
+        Some(namespace) => Cow::Owned(union_unique(namespace, message)),
+        None => Cow::Borrowed(message),
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(payload.as_ref());
+    let digest = hasher.finalize();
+    digest
+        .as_ref()
+        .try_into()
+        .expect("sha256 digest is 32 bytes")
+}
+
+/// A secp256k1 ECDSA signer: private scalar plus the derived Ethereum address.
+///
+/// Implements the 2026.5.0 [`Signer`] trait (namespaced path) so it can serve as the
+/// p2p identity signer, and exposes [`Ecdsa::sign_digest`] for the raw on-chain path.
+#[derive(Clone)]
+pub struct Ecdsa {
+    private: SigningKey,
+    address: Address,
+}
+
+impl Ecdsa {
+    /// Builds a signer from a [`PrivateKey`], deriving the Ethereum address.
+    pub fn new(private_key: PrivateKey) -> Self {
+        Self::from_signing_key(private_key.key)
+    }
+
+    /// Builds a signer directly from a `SigningKey`.
+    fn from_signing_key(private: SigningKey) -> Self {
+        let address = secret_key_to_address(&private);
+        Ecdsa { private, address }
+    }
+
+    /// Returns the private key.
+    pub fn private_key(&self) -> PrivateKey {
+        PrivateKey::from(self.private.clone())
+    }
+
+    /// Returns the signer's Ethereum address.
+    pub fn address(&self) -> Address {
+        self.address
+    }
+
+    /// Signs a raw 32-byte digest, used AS-IS (no prefix, no extra hashing).
+    ///
+    /// Produces the canonical low-s signature with the recovery id Ethereum's
+    /// `ecrecover` expects — byte-compatible with on-chain recovery-based
+    /// verification.
+    pub fn sign_digest(&self, digest: &[u8; DIGEST_LENGTH]) -> Signature {
+        let (sig, recovery_id) = self
+            .private
+            .sign_prehash_recoverable(digest)
+            .expect("signing over a 32-byte prehash cannot fail");
+        Signature::from_alloy(alloy_primitives::Signature::from((sig, recovery_id)))
+    }
+
+    /// Signs with the old `Option<&[u8]>` namespace semantics (see
+    /// [`signing_payload`]). The 2026.5.0 [`Signer`] trait delegates here with
+    /// `Some(namespace)`; internal digest signing uses `None`.
+    pub fn sign_message(&self, namespace: Option<&[u8]>, message: &[u8]) -> Signature {
+        self.sign_digest(&signing_payload(namespace, message))
+    }
+}
+
+impl Signer for Ecdsa {
+    type Signature = Signature;
+    type PublicKey = PublicKey;
+
+    fn sign(&self, namespace: &[u8], message: &[u8]) -> Signature {
+        self.sign_message(Some(namespace), message)
+    }
+
+    fn public_key(&self) -> PublicKey {
+        PublicKey::from(self.address)
+    }
+}
+
+impl Random for Ecdsa {
+    fn random(mut rng: impl CryptoRngCore) -> Self {
+        Self::from_signing_key(SigningKey::random(&mut rng))
+    }
+}
+
+impl Debug for Ecdsa {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print the private scalar.
+        f.debug_struct("Ecdsa")
+            .field("address", &self.address)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A secp256k1 private key: the scalar plus its 32-byte big-endian encoding.
+#[derive(Clone)]
+pub struct PrivateKey {
+    raw: [u8; PRIVATE_KEY_LENGTH],
+    key: SigningKey,
+}
+
+impl PartialEq for PrivateKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl Eq for PrivateKey {}
+
+impl FixedSize for PrivateKey {
+    const SIZE: usize = PRIVATE_KEY_LENGTH;
+}
+
+impl Write for PrivateKey {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.raw.write(buf);
+    }
+}
+
+impl Read for PrivateKey {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _cfg: &()) -> Result<Self, Error> {
+        let raw = <[u8; PRIVATE_KEY_LENGTH]>::read_cfg(buf, &())?;
+        // `from_slice` rejects zero scalars and values >= the curve order.
+        let key = SigningKey::from_slice(&raw)
+            .map_err(|_| Error::Invalid("ecdsa::PrivateKey", "invalid scalar"))?;
+        Ok(PrivateKey { raw, key })
+    }
+}
+
+impl Hash for PrivateKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+impl AsRef<[u8]> for PrivateKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl From<SigningKey> for PrivateKey {
+    fn from(key: SigningKey) -> Self {
+        let raw: [u8; PRIVATE_KEY_LENGTH] = key.to_bytes().into();
+        Self { raw, key }
+    }
+}
+
+impl TryFrom<&[u8]> for PrivateKey {
+    type Error = Error;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let raw: [u8; PRIVATE_KEY_LENGTH] = value
+            .try_into()
+            .map_err(|_| Error::InvalidLength(value.len()))?;
+        let key = SigningKey::from_slice(&raw)
+            .map_err(|_| Error::Invalid("ecdsa::PrivateKey", "invalid scalar"))?;
+        Ok(Self { raw, key })
+    }
+}
+
+impl TryFrom<&Vec<u8>> for PrivateKey {
+    type Error = Error;
+    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl TryFrom<Vec<u8>> for PrivateKey {
+    type Error = Error;
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl Debug for PrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never print key material.
+        write!(f, "ecdsa::PrivateKey(REDACTED)")
+    }
+}
+
+impl Display for PrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+/// A secp256k1 public identity: the signer's 20-byte Ethereum address.
+///
+/// This is the operator's registered EigenLayer address and doubles as the p2p
+/// identity AND the participant identity key of [`EcdsaScheme`] — participant
+/// indices derive from the byte ordering of these addresses, so the set must be
+/// identical on every process. Verification is recovery-based (the full public
+/// key is recovered from each 65-byte signature and reduced to an address).
+#[derive(Clone, Eq, PartialEq)]
+pub struct PublicKey {
+    raw: [u8; PUBLIC_KEY_LENGTH],
+}
+
+impl Span for PublicKey {}
+
+impl Array for PublicKey {}
+
+impl FixedSize for PublicKey {
+    const SIZE: usize = PUBLIC_KEY_LENGTH;
+}
+
+impl Write for PublicKey {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.raw.write(buf);
+    }
+}
+
+impl Read for PublicKey {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _cfg: &()) -> Result<Self, Error> {
+        let raw = <[u8; PUBLIC_KEY_LENGTH]>::read_cfg(buf, &())?;
+        // The zero address can never be recovered from a valid signature
+        // (`ecrecover` failure sentinel) — reject it as an identity outright.
+        if raw == [0u8; PUBLIC_KEY_LENGTH] {
+            return Err(Error::Invalid("ecdsa::PublicKey", "zero address"));
+        }
+        Ok(PublicKey { raw })
+    }
+}
+
+impl Hash for PublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+impl Ord for PublicKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.raw.cmp(&other.raw)
+    }
+}
+
+impl PartialOrd for PublicKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl AsRef<[u8]> for PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl Deref for PublicKey {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl From<Address> for PublicKey {
+    fn from(address: Address) -> Self {
+        Self { raw: address.0.0 }
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = Error;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != PUBLIC_KEY_LENGTH {
+            return Err(Error::InvalidLength(value.len()));
+        }
+        Self::read_cfg(&mut &*value, &())
+    }
+}
+
+impl TryFrom<&Vec<u8>> for PublicKey {
+    type Error = Error;
+    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl TryFrom<Vec<u8>> for PublicKey {
+    type Error = Error;
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl Debug for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_hex(&self.raw, f)
+    }
+}
+
+impl Display for PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_hex(&self.raw, f)
+    }
+}
+
+impl Verifier for PublicKey {
+    type Signature = Signature;
+
+    fn verify(&self, namespace: &[u8], message: &[u8], signature: &Signature) -> bool {
+        self.verify_message(Some(namespace), message, signature)
+    }
+}
+
+impl CPublicKey for PublicKey {}
+
+impl PublicKey {
+    /// Builds a public key from a `0x`-prefixed (or bare) hex Ethereum address
+    /// string, e.g. from an operator's public key-file.
+    ///
+    /// Returns `None` on malformed input or the zero address.
+    pub fn from_address_str(address: &str) -> Option<Self> {
+        let address: Address = address.trim().parse().ok()?;
+        if address == Address::ZERO {
+            return None;
+        }
+        Some(PublicKey::from(address))
+    }
+
+    /// Returns the Ethereum address.
+    pub fn address(&self) -> Address {
+        Address::from(self.raw)
+    }
+
+    /// Verifies a signature over a raw 32-byte digest (the on-chain path):
+    /// recover the signer address from the signature and compare.
+    pub fn verify_digest(&self, digest: &[u8; DIGEST_LENGTH], signature: &Signature) -> bool {
+        signature.recover(digest) == Some(self.address())
+    }
+
+    /// Verifies with the old `Option<&[u8]>` namespace semantics (see
+    /// [`signing_payload`]). The 2026.5.0 [`Verifier`] trait delegates here with
+    /// `Some(namespace)`; internal digest verification uses `None`.
+    pub fn verify_message(
+        &self,
+        namespace: Option<&[u8]>,
+        message: &[u8],
+        signature: &Signature,
+    ) -> bool {
+        self.verify_digest(&signing_payload(namespace, message), signature)
+    }
+}
+
+/// A secp256k1 ECDSA signature: 65 bytes `r || s || v` with `v` in {27, 28}.
+///
+/// Decoding enforces the canonical form (low-s, non-zero `r`/`s`, Electrum `v`),
+/// so equal signatures always have equal bytes. The byte layout is exactly what
+/// an Ethereum `ecrecover`-based verifier consumes on-chain.
+#[derive(Clone, Eq, PartialEq)]
+pub struct Signature {
+    raw: [u8; SIGNATURE_LENGTH],
+    sig: alloy_primitives::Signature,
+}
+
+impl Span for Signature {}
+
+impl Array for Signature {}
+
+impl FixedSize for Signature {
+    const SIZE: usize = SIGNATURE_LENGTH;
+}
+
+impl Write for Signature {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.raw.write(buf);
+    }
+}
+
+impl Read for Signature {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _cfg: &()) -> Result<Self, Error> {
+        let raw = <[u8; SIGNATURE_LENGTH]>::read_cfg(buf, &())?;
+        // This runs on untrusted network bytes (via `Lazy<Signature>` decode and
+        // certificate decode) — it must error, never panic, and must only accept
+        // the canonical encoding so byte equality is signature equality.
+        let v = raw[SIGNATURE_LENGTH - 1];
+        if v != 27 && v != 28 {
+            return Err(Error::Invalid("ecdsa::Signature", "v must be 27 or 28"));
+        }
+        let sig = alloy_primitives::Signature::from_raw_array(&raw)
+            .map_err(|_| Error::Invalid("ecdsa::Signature", "invalid signature"))?;
+        if sig.r() == U256::ZERO || sig.s() == U256::ZERO {
+            return Err(Error::Invalid("ecdsa::Signature", "zero r or s"));
+        }
+        if sig.s() > HALF_CURVE_ORDER {
+            return Err(Error::Invalid("ecdsa::Signature", "high-s (malleable)"));
+        }
+        Ok(Signature { raw, sig })
+    }
+}
+
+impl Hash for Signature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+impl Ord for Signature {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.raw.cmp(&other.raw)
+    }
+}
+
+impl PartialOrd for Signature {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl Deref for Signature {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+impl TryFrom<&[u8]> for Signature {
+    type Error = Error;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != SIGNATURE_LENGTH {
+            return Err(Error::InvalidLength(value.len()));
+        }
+        Self::read_cfg(&mut &*value, &())
+    }
+}
+
+impl TryFrom<&Vec<u8>> for Signature {
+    type Error = Error;
+    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl TryFrom<Vec<u8>> for Signature {
+    type Error = Error;
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl Debug for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_hex(&self.raw, f)
+    }
+}
+
+impl Display for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_hex(&self.raw, f)
+    }
+}
+
+impl CSignature for Signature {}
+
+impl Signature {
+    /// Wraps an alloy signature, capturing the canonical 65-byte encoding
+    /// (`as_bytes` writes `v` as `27 + y_parity`).
+    fn from_alloy(sig: alloy_primitives::Signature) -> Self {
+        Self {
+            raw: sig.as_bytes(),
+            sig,
+        }
+    }
+
+    /// Recovers the signer's Ethereum address from a raw 32-byte digest.
+    ///
+    /// Returns `None` for cryptographically invalid signatures (recovery failure).
+    pub fn recover(&self, digest: &[u8; DIGEST_LENGTH]) -> Option<Address> {
+        self.sig
+            .recover_address_from_prehash(&B256::from(*digest))
+            .ok()
+    }
+}
+
+/// Builds a signer from a private-key string (an operator key-file format).
+///
+/// Accepts a `0x`-prefixed hex scalar (the EigenLayer `*.private.ecdsa.key.json`
+/// format), a bare 64-char hex scalar, or a decimal scalar (legacy key-file
+/// format).
+///
+/// # Panics
+///
+/// Panics on a malformed key. Only call with operator-provided configuration at
+/// startup, never with network input.
+pub fn get_signer(key: &str) -> Ecdsa {
+    let key = key.trim();
+    let bytes: [u8; PRIVATE_KEY_LENGTH] = if let Some(hex_key) = key.strip_prefix("0x") {
+        let decoded = hex::decode(hex_key).expect("invalid hex private key");
+        decoded
+            .as_slice()
+            .try_into()
+            .expect("hex private key must be 32 bytes")
+    } else if key.len() == 2 * PRIVATE_KEY_LENGTH && key.chars().all(|c| c.is_ascii_hexdigit()) {
+        let decoded = hex::decode(key).expect("invalid hex private key");
+        decoded
+            .as_slice()
+            .try_into()
+            .expect("hex private key must be 32 bytes")
+    } else {
+        let value = U256::from_str_radix(key, 10).expect("invalid decimal private key");
+        value.to_be_bytes()
+    };
+    let signing_key = SigningKey::from_slice(&bytes).expect("private key is not a valid scalar");
+    Ecdsa::from_signing_key(signing_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_codec::{DecodeExt, Encode};
+    use commonware_utils::test_rng;
+
+    /// A fixed digest for deterministic tests.
+    fn digest() -> [u8; DIGEST_LENGTH] {
+        let mut hasher = Sha256::new();
+        hasher.update(b"commonware-restaking ecdsa test digest");
+        hasher.finalize().as_ref().try_into().unwrap()
+    }
+
+    #[test]
+    fn sign_digest_roundtrip() {
+        let signer = get_signer("12345");
+        let sig = signer.sign_digest(&digest());
+        assert!(signer.public_key().verify_digest(&digest(), &sig));
+
+        // Wrong digest is rejected.
+        let mut wrong = digest();
+        wrong[0] ^= 0x01;
+        assert!(!signer.public_key().verify_digest(&wrong, &sig));
+
+        // Wrong key is rejected.
+        let other = get_signer("54321");
+        assert!(!other.public_key().verify_digest(&digest(), &sig));
+    }
+
+    #[test]
+    fn signature_is_ecrecover_canonical() {
+        // The 65-byte encoding must be `r || s || v` with v in {27, 28} and low-s —
+        // exactly what an on-chain `ecrecover`-based verifier consumes. If this test
+        // breaks, certificates will no longer verify on-chain.
+        for key in ["101", "202", "303", "404"] {
+            let signer = get_signer(key);
+            let sig = signer.sign_digest(&digest());
+            let raw = sig.as_ref();
+            assert_eq!(raw.len(), 65);
+            let v = raw[64];
+            assert!(v == 27 || v == 28, "v must be Electrum notation");
+            let s = U256::from_be_slice(&raw[32..64]);
+            assert!(s <= HALF_CURVE_ORDER, "s must be low (EIP-2)");
+            // Recovery yields the signer's address.
+            assert_eq!(sig.recover(&digest()), Some(signer.address()));
+        }
+    }
+
+    #[test]
+    fn get_signer_parses_hex_and_decimal() {
+        // 0x-prefixed hex, bare hex, and decimal all derive the same key.
+        let decimal = get_signer("12345");
+        let hex_key = format!("0x{}", hex::encode(decimal.private_key().as_ref()));
+        let from_hex = get_signer(&hex_key);
+        assert_eq!(from_hex.address(), decimal.address());
+        let bare = hex_key.strip_prefix("0x").unwrap().to_string();
+        assert_eq!(get_signer(&bare).address(), decimal.address());
+    }
+
+    #[test]
+    fn address_matches_alloy_signer() {
+        // Parity with alloy's own local-signer wallet: same private key, same
+        // address.
+        let key = get_signer("31337");
+        let hex_key = format!("0x{}", hex::encode(key.private_key().as_ref()));
+        let alloy_signer: alloy_signer_local::PrivateKeySigner = hex_key.parse().unwrap();
+        assert_eq!(key.address(), alloy_signer.address());
+    }
+
+    #[test]
+    fn sign_digest_matches_legacy_none_namespace_semantics() {
+        let signer = get_signer("999");
+        let raw = signer.sign_digest(&digest());
+        let legacy = signer.sign_message(None, &digest());
+        assert_eq!(raw.as_ref(), legacy.as_ref());
+    }
+
+    #[test]
+    fn namespaced_signing_is_domain_separated() {
+        let signer = get_signer("777");
+        let public = signer.public_key();
+        let message = b"some message";
+
+        let sig = Signer::sign(&signer, b"ns-a", message);
+        assert!(Verifier::verify(&public, b"ns-a", message, &sig));
+        // Different namespace or message fails.
+        assert!(!Verifier::verify(&public, b"ns-b", message, &sig));
+        assert!(!Verifier::verify(&public, b"ns-a", b"other message", &sig));
+
+        // The namespaced path never collides with the raw digest path, even when
+        // the message is 32 bytes.
+        let sig32 = Signer::sign(&signer, b"ns-a", &digest());
+        assert_ne!(sig32.as_ref(), signer.sign_digest(&digest()).as_ref());
+    }
+
+    #[test]
+    fn none_namespace_non_digest_message_is_hashed() {
+        let signer = get_signer("31337");
+        let message = b"not thirty-two bytes";
+        let sig = signer.sign_message(None, message);
+
+        let mut hasher = Sha256::new();
+        hasher.update(message);
+        let hashed: [u8; DIGEST_LENGTH] = hasher.finalize().as_ref().try_into().unwrap();
+        assert_eq!(sig.as_ref(), signer.sign_digest(&hashed).as_ref());
+    }
+
+    #[test]
+    fn public_key_codec_roundtrip() {
+        let public = get_signer("424242").public_key();
+        let encoded = public.encode();
+        assert_eq!(encoded.len(), PublicKey::SIZE);
+        let decoded = PublicKey::decode(encoded).unwrap();
+        assert_eq!(decoded, public);
+    }
+
+    #[test]
+    fn signature_codec_roundtrip() {
+        let sig = get_signer("424242").sign_digest(&digest());
+        let encoded = sig.encode();
+        assert_eq!(encoded.len(), Signature::SIZE);
+        let decoded = Signature::decode(encoded).unwrap();
+        assert_eq!(decoded, sig);
+        // The decoded signature still recovers.
+        assert_eq!(
+            decoded.recover(&digest()),
+            Some(get_signer("424242").address())
+        );
+    }
+
+    #[test]
+    fn private_key_codec_roundtrip() {
+        let private = get_signer("13").private_key();
+        let encoded = private.encode();
+        assert_eq!(encoded.len(), PrivateKey::SIZE);
+        let decoded = PrivateKey::decode(encoded).unwrap();
+        assert_eq!(decoded, private);
+        // Re-derived signer produces identical signatures.
+        let rebuilt = Ecdsa::new(decoded);
+        assert_eq!(
+            rebuilt.sign_digest(&digest()).as_ref(),
+            get_signer("13").sign_digest(&digest()).as_ref()
+        );
+    }
+
+    #[test]
+    fn signature_decode_rejects_non_canonical() {
+        let sig = get_signer("7").sign_digest(&digest());
+        let raw: [u8; SIGNATURE_LENGTH] = sig.as_ref().try_into().unwrap();
+
+        // Bad parity byte.
+        let mut bad_v = raw;
+        bad_v[64] = 29;
+        assert!(Signature::decode(&bad_v[..]).is_err());
+        let mut zero_v = raw;
+        zero_v[64] = 0;
+        assert!(
+            Signature::decode(&zero_v[..]).is_err(),
+            "y-parity form (v=0/1) must be rejected to keep the encoding canonical"
+        );
+
+        // High-s twin (same ecrecover result under a naive verifier) is rejected.
+        let curve_order = U256::from_be_slice(&[
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
+            0xd0, 0x36, 0x41, 0x41,
+        ]);
+        let s = U256::from_be_slice(&raw[32..64]);
+        let high_s = curve_order - s;
+        let mut malleated = raw;
+        malleated[32..64].copy_from_slice(&high_s.to_be_bytes::<32>());
+        malleated[64] = if raw[64] == 27 { 28 } else { 27 };
+        assert!(Signature::decode(&malleated[..]).is_err());
+
+        // Zero r / zero s.
+        let mut zero_r = raw;
+        zero_r[0..32].fill(0);
+        assert!(Signature::decode(&zero_r[..]).is_err());
+        let mut zero_s = raw;
+        zero_s[32..64].fill(0);
+        assert!(Signature::decode(&zero_s[..]).is_err());
+    }
+
+    #[test]
+    fn malformed_bytes_error_instead_of_panicking() {
+        assert!(PublicKey::decode(&[0u8; PUBLIC_KEY_LENGTH][..]).is_err()); // zero address
+        assert!(Signature::decode(&[0xffu8; SIGNATURE_LENGTH][..]).is_err());
+        assert!(PrivateKey::decode(&[0u8; PRIVATE_KEY_LENGTH][..]).is_err()); // zero scalar
+        assert!(PrivateKey::decode(&[0xffu8; PRIVATE_KEY_LENGTH][..]).is_err()); // >= order
+    }
+
+    #[test]
+    fn try_from_rejects_bad_lengths() {
+        assert!(matches!(
+            PublicKey::try_from(&[1u8; 5][..]),
+            Err(Error::InvalidLength(5))
+        ));
+        assert!(matches!(
+            Signature::try_from(&[1u8; 33][..]),
+            Err(Error::InvalidLength(33))
+        ));
+        assert!(matches!(
+            PrivateKey::try_from(&[1u8; 31][..]),
+            Err(Error::InvalidLength(31))
+        ));
+    }
+
+    #[test]
+    fn from_address_str_roundtrip() {
+        let signer = get_signer("2718281828");
+        let hex_addr = format!("{}", signer.public_key());
+        let rebuilt = PublicKey::from_address_str(&hex_addr).unwrap();
+        assert_eq!(rebuilt, signer.public_key());
+
+        assert!(PublicKey::from_address_str("not an address").is_none());
+        assert!(
+            PublicKey::from_address_str("0x0000000000000000000000000000000000000000").is_none()
+        );
+    }
+
+    #[test]
+    fn random_signers_are_distinct_and_functional() {
+        let mut rng = test_rng();
+        let a = Ecdsa::random(&mut rng);
+        let b = Ecdsa::random(&mut rng);
+        assert_ne!(a.public_key(), b.public_key());
+        let sig = a.sign_digest(&digest());
+        assert!(a.public_key().verify_digest(&digest(), &sig));
+
+        // `from_seed` (provided by the Signer trait via Random) is deterministic.
+        let s1 = Ecdsa::from_seed(7);
+        let s2 = Ecdsa::from_seed(7);
+        assert_eq!(s1.public_key(), s2.public_key());
+    }
+}

--- a/core/src/ecdsa/scheme.rs
+++ b/core/src/ecdsa/scheme.rs
@@ -1,0 +1,812 @@
+//! secp256k1 ECDSA multisig [`certificate::Scheme`](commonware_cryptography::certificate::Scheme)
+//! for the `commonware-consensus` aggregation engine.
+//!
+//! [`EcdsaScheme`] mirrors the secp256r1 multisig reference implementation
+//! (`commonware_cryptography::certificate::secp256r1`) with two deliberate
+//! differences:
+//!
+//! 1. **Signing covers ONLY the raw 32-byte digest** — the digest is signed as an
+//!    Ethereum prehash with no namespace and no height (see [`Ecdsa::sign_digest`]).
+//!    This is what keeps assembled certificates verifiable by an on-chain verifier
+//!    that recovers each signer with exactly `ecrecover(task_digest, v, r, s)`.
+//! 2. The participant identity is the operator's 20-byte Ethereum address (the key
+//!    EigenLayer registration is bound to), and verification is recovery-based —
+//!    no separate signing public key needs distribution.
+//!
+//! # Replay domain (READ BEFORE "FIXING")
+//!
+//! Because the signature binds only the digest — not the `Item`'s height, the epoch,
+//! or any namespace — signatures for the same digest are interchangeable across
+//! heights and deployments. This matches the security model of the BN254 scheme in
+//! [`crate::bn254`]: the digest itself must bind the full task content, and the
+//! consuming contract must enforce its own replay protection (e.g. strict ordering
+//! of state-transition indices), so replaying an identical digest at another height
+//! submits the same state transition, which the contract accepts at most once. Do
+//! NOT add the height or a namespace to the preimage — that would break on-chain
+//! verification.
+//!
+//! Unlike BLS aggregation there is no rogue-key concern: every signature is verified
+//! individually against its participant's address.
+
+use super::{Ecdsa, PrivateKey, PublicKey, Signature};
+use alloy_primitives::Address;
+use bytes::{Buf, BufMut};
+use commonware_codec::{EncodeSize, Error, Read, ReadExt, Write};
+use commonware_consensus::aggregation::types::Item;
+use commonware_cryptography::certificate::{Attestation, Scheme, Signers};
+use commonware_cryptography::{Digest, Signer as _};
+use commonware_parallel::Strategy;
+use commonware_utils::ordered::{Quorum, Set};
+use commonware_utils::{Faults, Participant};
+use rand_core::CryptoRngCore;
+
+/// Extracts the raw 32 digest bytes from an [`Item`]'s digest.
+///
+/// The scheme only supports 32-byte digests (`sha256::Digest` in this system):
+/// the on-chain verifier recovers signatures over 32-byte task digests. Returns
+/// `None` for any other digest width instead of panicking so a mis-instantiated
+/// scheme fails verification rather than the process.
+fn item_digest<D: Digest>(item: &Item<D>) -> Option<[u8; 32]> {
+    item.digest.as_ref().try_into().ok()
+}
+
+/// secp256k1 ECDSA multisig certificate scheme over a fixed participant set.
+///
+/// Participant indices are positions in the `ordered::Set` of operator addresses
+/// (sorted by address bytes) — every node and the router MUST build the set from
+/// the same operator list or attestations will be attributed to the wrong signer
+/// and blocked by the engine (`PeerMismatch`).
+#[derive(Clone, Debug)]
+pub struct EcdsaScheme {
+    /// Ordered operator addresses; participant indices are positions here.
+    participants: Set<PublicKey>,
+    /// Our participant index and signer; `None` for verifier-only instances.
+    signer: Option<(Participant, Ecdsa)>,
+}
+
+impl EcdsaScheme {
+    /// Creates a signing scheme instance.
+    ///
+    /// Returns `None` if `private_key`'s address is not in the participant set
+    /// (mirroring the multisig reference implementations).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the participant set is empty — a construction-time configuration
+    /// error, never network input (quorum math panics on `n == 0`).
+    pub fn signer(participants: Set<PublicKey>, private_key: PrivateKey) -> Option<Self> {
+        Self::validate_participants(&participants);
+        let signer = Ecdsa::new(private_key);
+        let index = participants.index(&signer.public_key())?;
+        Some(Self {
+            participants,
+            signer: Some((index, signer)),
+        })
+    }
+
+    /// Creates a verifier-only scheme instance (`me() == None`): validates acks,
+    /// assembles and verifies certificates, but never signs. This is what the router
+    /// runs.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the participant set is empty — a construction-time configuration
+    /// error, never network input.
+    pub fn verifier(participants: Set<PublicKey>) -> Self {
+        Self::validate_participants(&participants);
+        Self {
+            participants,
+            signer: None,
+        }
+    }
+
+    fn validate_participants(participants: &Set<PublicKey>) {
+        assert!(
+            !participants.is_empty(),
+            "participant set must not be empty (quorum math panics on n == 0)"
+        );
+    }
+
+    /// Maps a certificate's signer bitmap to the signers' Ethereum addresses
+    /// (participant order). The router pairs these with the certificate's
+    /// signatures for the on-chain submission.
+    ///
+    /// Out-of-range bits are skipped; only call with a bitmap from a certificate
+    /// that passed [`Scheme::verify_certificate`] (which enforces
+    /// `signers.len() == participants.len()`).
+    pub fn signer_addresses(&self, signers: &Signers) -> Vec<Address> {
+        signers
+            .iter()
+            .filter_map(|participant| self.participants.key(participant).map(|k| k.address()))
+            .collect()
+    }
+}
+
+impl Scheme for EcdsaScheme {
+    type Subject<'a, D: Digest> = &'a Item<D>;
+    type PublicKey = PublicKey;
+    type Signature = Signature;
+    type Certificate = EcdsaCertificate;
+
+    fn me(&self) -> Option<Participant> {
+        self.signer.as_ref().map(|(index, _)| *index)
+    }
+
+    fn participants(&self) -> &Set<PublicKey> {
+        &self.participants
+    }
+
+    /// Signs the raw digest ONLY (Ethereum prehash semantics).
+    ///
+    /// The subject's height and the derived `_AGG_ACK` namespace are deliberately
+    /// ignored; see the module docs for why this is required for on-chain
+    /// verification and why the digest-only replay domain is acceptable.
+    fn sign<D: Digest>(&self, subject: Self::Subject<'_, D>) -> Option<Attestation<Self>> {
+        let (index, signer) = self.signer.as_ref()?;
+        let digest = item_digest(subject)?;
+        let signature = signer.sign_digest(&digest);
+        Some(Attestation {
+            signer: *index,
+            signature: signature.into(),
+        })
+    }
+
+    fn verify_attestation<R, D>(
+        &self,
+        _rng: &mut R,
+        subject: Self::Subject<'_, D>,
+        attestation: &Attestation<Self>,
+        _strategy: &impl Strategy,
+    ) -> bool
+    where
+        R: CryptoRngCore,
+        D: Digest,
+    {
+        let Some(public_key) = self.participants.key(attestation.signer) else {
+            return false;
+        };
+        // Lazy decode of untrusted bytes: `None` means malformed — reject, never
+        // panic.
+        let Some(signature) = attestation.signature.get() else {
+            return false;
+        };
+        let Some(digest) = item_digest(subject) else {
+            return false;
+        };
+        public_key.verify_digest(&digest, signature)
+    }
+
+    fn assemble<I, M>(
+        &self,
+        attestations: I,
+        _strategy: &impl Strategy,
+    ) -> Option<Self::Certificate>
+    where
+        I: IntoIterator<Item = Attestation<Self>>,
+        I::IntoIter: Send,
+        M: Faults,
+    {
+        // Collect the signers and signatures. Out-of-range indices MUST abort before
+        // `Signers::from` (which panics on them); duplicate signers are documented
+        // UB for `assemble` — the engine dedupes by participant index before calling.
+        let mut entries = Vec::new();
+        for Attestation { signer, signature } in attestations {
+            if usize::from(signer) >= self.participants.len() {
+                return None;
+            }
+            let signature = signature.get().cloned()?;
+            entries.push((signer, signature));
+        }
+        if entries.len() < self.participants.quorum::<M>() as usize {
+            return None;
+        }
+
+        // Certificate signatures are stored in ascending participant-index order —
+        // the same order the bitmap iterates — so verification (and the on-chain
+        // submission) can zip bitmap indices with signatures positionally.
+        entries.sort_by_key(|(signer, _)| *signer);
+        let (signers, signatures): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
+        let signers = Signers::from(self.participants.len(), signers);
+
+        Some(EcdsaCertificate {
+            signers,
+            signatures,
+        })
+    }
+
+    fn verify_certificate<R, D, M>(
+        &self,
+        _rng: &mut R,
+        subject: Self::Subject<'_, D>,
+        certificate: &Self::Certificate,
+        _strategy: &impl Strategy,
+    ) -> bool
+    where
+        R: CryptoRngCore,
+        D: Digest,
+        M: Faults,
+    {
+        // The decoded bitmap length is only upper-bounded by the codec config;
+        // enforce the exact participant-set size here (a truncated or extended
+        // bitmap would otherwise shift signer indices).
+        if certificate.signers.len() != self.participants.len() {
+            return false;
+        }
+
+        // Every bitmap signer must have exactly one signature.
+        if certificate.signers.count() != certificate.signatures.len() {
+            return false;
+        }
+
+        // Enforce the quorum under the caller's fault model (the aggregation engine
+        // always passes N3f1: quorum = n - (n-1)/3).
+        if certificate.signers.count() < self.participants.quorum::<M>() as usize {
+            return false;
+        }
+
+        let Some(digest) = item_digest(subject) else {
+            return false;
+        };
+
+        // Verify each signature against its bitmap participant's address.
+        for (signer, signature) in certificate.signers.iter().zip(&certificate.signatures) {
+            let Some(public_key) = self.participants.key(signer) else {
+                return false;
+            };
+            if !public_key.verify_digest(&digest, signature) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn is_attributable() -> bool {
+        // Certificates carry the signer bitmap alongside per-signer signatures,
+        // each independently verifiable.
+        true
+    }
+
+    fn is_batchable() -> bool {
+        // Recovery-based verification has no batch form; eager per-certificate
+        // verification is preferred.
+        false
+    }
+
+    fn certificate_codec_config(&self) -> <Self::Certificate as Read>::Cfg {
+        self.participants.len()
+    }
+
+    fn certificate_codec_config_unbounded() -> <Self::Certificate as Read>::Cfg {
+        u32::MAX as usize
+    }
+}
+
+/// Certificate formed by the bitmap of contributing signers plus their individual
+/// 65-byte ECDSA signatures in ascending participant-index order (the bitmap's
+/// iteration order).
+///
+/// Codec: `signers` (varint-length bitmap) followed by exactly `signers.count()`
+/// fixed 65-byte signatures; `Read::Cfg` is the maximum participant count (upper
+/// bound only — exact sizing is enforced by [`Scheme::verify_certificate`]).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EcdsaCertificate {
+    /// Bitmap of participant indices that contributed signatures.
+    pub signers: Signers,
+    /// Per-signer signatures, index-aligned with the bitmap's ascending iteration.
+    pub signatures: Vec<Signature>,
+}
+
+impl Write for EcdsaCertificate {
+    fn write(&self, writer: &mut impl BufMut) {
+        self.signers.write(writer);
+        for signature in &self.signatures {
+            signature.write(writer);
+        }
+    }
+}
+
+impl EncodeSize for EcdsaCertificate {
+    fn encode_size(&self) -> usize {
+        self.signers.encode_size()
+            + self
+                .signatures
+                .iter()
+                .map(|signature| signature.encode_size())
+                .sum::<usize>()
+    }
+}
+
+impl Read for EcdsaCertificate {
+    type Cfg = usize;
+
+    fn read_cfg(reader: &mut impl Buf, max_participants: &usize) -> Result<Self, Error> {
+        let signers = Signers::read_cfg(reader, max_participants)?;
+        if signers.count() == 0 {
+            return Err(Error::Invalid(
+                "ecdsa::EcdsaCertificate",
+                "Certificate contains no signers",
+            ));
+        }
+
+        // Exactly one signature per bitmap signer. Decoding (and canonical-form
+        // validation) is eager: certificates are rare and small, and this rejects
+        // malformed bytes at the decode boundary.
+        let mut signatures = Vec::with_capacity(signers.count());
+        for _ in 0..signers.count() {
+            signatures.push(Signature::read(reader)?);
+        }
+
+        Ok(Self {
+            signers,
+            signatures,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ecdsa::get_signer;
+    use commonware_codec::{Decode, Encode};
+    use commonware_consensus::aggregation::types::{Ack, Certificate as AggCertificate};
+    use commonware_consensus::types::{Epoch, Height};
+    use commonware_cryptography::sha256::Digest as Sha256Digest;
+    use commonware_cryptography::{Hasher as _, Sha256};
+    use commonware_parallel::Sequential;
+    use commonware_utils::{N3f1, TryCollect, test_rng};
+
+    /// Deterministic signer set with participant-ordered schemes.
+    ///
+    /// Returns `(signers, verifier)` where `signers[i]` is the scheme whose
+    /// participant index is `i` (i.e. sorted by address bytes).
+    fn setup(n: usize) -> (Vec<EcdsaScheme>, EcdsaScheme) {
+        let keys: Vec<Ecdsa> = (0..n).map(|i| Ecdsa::from_seed(i as u64)).collect();
+        let participants: Set<PublicKey> = keys
+            .iter()
+            .map(|k| k.public_key())
+            .try_collect()
+            .expect("no duplicate keys");
+
+        let mut schemes: Vec<EcdsaScheme> = keys
+            .iter()
+            .map(|k| {
+                EcdsaScheme::signer(participants.clone(), k.private_key())
+                    .expect("key is in participant set")
+            })
+            .collect();
+        schemes.sort_by_key(|s| s.me().expect("signer scheme has an index"));
+        let verifier = EcdsaScheme::verifier(participants);
+        (schemes, verifier)
+    }
+
+    fn item(height: u64, payload: &[u8]) -> Item<Sha256Digest> {
+        let mut hasher = Sha256::new();
+        hasher.update(payload);
+        Item {
+            height: Height::new(height),
+            digest: hasher.finalize(),
+        }
+    }
+
+    fn sign_all(
+        schemes: &[EcdsaScheme],
+        item: &Item<Sha256Digest>,
+        count: usize,
+    ) -> Vec<Attestation<EcdsaScheme>> {
+        schemes
+            .iter()
+            .take(count)
+            .map(|s| s.sign::<Sha256Digest>(item).expect("signer can sign"))
+            .collect()
+    }
+
+    // (a) Attestation sign/verify round-trip, including wrong-digest rejection.
+    #[test]
+    fn attestation_roundtrip() {
+        let mut rng = test_rng();
+        let (schemes, verifier) = setup(4);
+        let subject = item(1, b"task payload");
+
+        for scheme in &schemes {
+            let attestation = scheme.sign::<Sha256Digest>(&subject).unwrap();
+            assert_eq!(Some(attestation.signer), scheme.me());
+            assert!(verifier.verify_attestation::<_, Sha256Digest>(
+                &mut rng,
+                &subject,
+                &attestation,
+                &Sequential,
+            ));
+
+            // Wrong digest rejected.
+            let wrong = item(1, b"different payload");
+            assert!(!verifier.verify_attestation::<_, Sha256Digest>(
+                &mut rng,
+                &wrong,
+                &attestation,
+                &Sequential,
+            ));
+
+            // Attributing the signature to another participant rejected.
+            let mut reattributed = attestation.clone();
+            reattributed.signer =
+                Participant::new((attestation.signer.get() + 1) % schemes.len() as u32);
+            assert!(!verifier.verify_attestation::<_, Sha256Digest>(
+                &mut rng,
+                &subject,
+                &reattributed,
+                &Sequential,
+            ));
+
+            // Out-of-range signer index rejected (not panicking).
+            let mut out_of_range = attestation.clone();
+            out_of_range.signer = Participant::new(999);
+            assert!(!verifier.verify_attestation::<_, Sha256Digest>(
+                &mut rng,
+                &subject,
+                &out_of_range,
+                &Sequential,
+            ));
+        }
+    }
+
+    #[test]
+    fn verifier_cannot_sign() {
+        let (_, verifier) = setup(4);
+        assert!(verifier.me().is_none());
+        assert!(verifier.sign::<Sha256Digest>(&item(1, b"x")).is_none());
+    }
+
+    // The signature binds only the digest — the same digest at another height
+    // produces the same attestation signature (see module docs for why this is
+    // intentional and safe).
+    #[test]
+    fn signature_is_height_independent() {
+        let (schemes, _) = setup(4);
+        let a = item(1, b"same payload");
+        let b = item(2, b"same payload");
+        let sig_a = schemes[0].sign::<Sha256Digest>(&a).unwrap();
+        let sig_b = schemes[0].sign::<Sha256Digest>(&b).unwrap();
+        assert_eq!(
+            sig_a.signature.get().unwrap().as_ref(),
+            sig_b.signature.get().unwrap().as_ref()
+        );
+    }
+
+    // (b) Assemble below quorum returns None; at quorum the certificate verifies.
+    #[test]
+    fn assemble_quorum_boundary_n4() {
+        let mut rng = test_rng();
+        let (schemes, verifier) = setup(4);
+        let subject = item(3, b"n4 task");
+        let quorum = verifier.participants().quorum::<N3f1>() as usize;
+        assert_eq!(quorum, 3); // n=4 → f=1 → quorum=3
+
+        // Below quorum: None.
+        let below = sign_all(&schemes, &subject, quorum - 1);
+        assert!(verifier.assemble::<_, N3f1>(below, &Sequential).is_none());
+
+        // At quorum: Some, and verify_certificate accepts.
+        let at = sign_all(&schemes, &subject, quorum);
+        let certificate = verifier.assemble::<_, N3f1>(at, &Sequential).unwrap();
+        assert_eq!(certificate.signers.count(), quorum);
+        assert_eq!(certificate.signers.len(), 4);
+        assert_eq!(certificate.signatures.len(), quorum);
+        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &certificate,
+            &Sequential,
+        ));
+
+        // Wrong digest rejected.
+        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &item(3, b"other task"),
+            &certificate,
+            &Sequential,
+        ));
+    }
+
+    #[test]
+    fn assemble_quorum_boundary_n3() {
+        let mut rng = test_rng();
+        let (schemes, verifier) = setup(3);
+        let subject = item(9, b"n3 task");
+        let quorum = verifier.participants().quorum::<N3f1>() as usize;
+        assert_eq!(quorum, 3); // n=3 → f=0 → quorum=3 (all signers)
+
+        let below = sign_all(&schemes, &subject, 2);
+        assert!(verifier.assemble::<_, N3f1>(below, &Sequential).is_none());
+
+        let at = sign_all(&schemes, &subject, 3);
+        let certificate = verifier.assemble::<_, N3f1>(at, &Sequential).unwrap();
+        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &certificate,
+            &Sequential,
+        ));
+    }
+
+    // Assemble must order signatures by participant index regardless of the
+    // order attestations arrive in.
+    #[test]
+    fn assemble_orders_signatures_by_participant_index() {
+        let mut rng = test_rng();
+        let (schemes, verifier) = setup(4);
+        let subject = item(12, b"unordered attestations");
+
+        let mut attestations = sign_all(&schemes, &subject, 3);
+        attestations.reverse();
+        let certificate = verifier
+            .assemble::<_, N3f1>(attestations, &Sequential)
+            .unwrap();
+        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &certificate,
+            &Sequential,
+        ));
+    }
+
+    #[test]
+    fn assemble_rejects_out_of_range_signer() {
+        let (schemes, verifier) = setup(4);
+        let subject = item(4, b"task");
+        let mut attestations = sign_all(&schemes, &subject, 3);
+        attestations[0].signer = Participant::new(999);
+        // Must return None (not panic in Signers::from).
+        assert!(
+            verifier
+                .assemble::<_, N3f1>(attestations, &Sequential)
+                .is_none()
+        );
+    }
+
+    // (c) Tampered bitmap / signature list / wrong participant count rejected.
+    #[test]
+    fn tampered_certificates_rejected() {
+        let mut rng = test_rng();
+        let (schemes, verifier) = setup(4);
+        let subject = item(5, b"tamper me");
+        let attestations = sign_all(&schemes, &subject, 3);
+        let certificate = verifier
+            .assemble::<_, N3f1>(attestations, &Sequential)
+            .unwrap();
+
+        // Claiming an extra signer that did not sign fails (count mismatch).
+        let mut extra_signer: Vec<Participant> = certificate.signers.iter().collect();
+        extra_signer.push(Participant::new(3));
+        let tampered = EcdsaCertificate {
+            signers: Signers::from(4, extra_signer),
+            signatures: certificate.signatures.clone(),
+        };
+        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &tampered,
+            &Sequential,
+        ));
+
+        // Dropping a signer from the bitmap (below quorum) is rejected.
+        let fewer: Vec<Participant> = certificate.signers.iter().take(2).collect();
+        let below_quorum = EcdsaCertificate {
+            signers: Signers::from(4, fewer),
+            signatures: certificate.signatures[..2].to_vec(),
+        };
+        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &below_quorum,
+            &Sequential,
+        ));
+
+        // Swapping which participants are claimed (same count) fails recovery.
+        let signers: Vec<Participant> = certificate.signers.iter().collect();
+        let swapped_participants: Vec<Participant> = signers
+            .iter()
+            .map(|p| Participant::new((p.get() + 1) % 4))
+            .collect();
+        let swapped = EcdsaCertificate {
+            signers: Signers::from(4, swapped_participants),
+            signatures: certificate.signatures.clone(),
+        };
+        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &swapped,
+            &Sequential,
+        ));
+
+        // Reordering the signature list breaks positional attribution.
+        let mut reordered = certificate.clone();
+        reordered.signatures.swap(0, 1);
+        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &reordered,
+            &Sequential,
+        ));
+
+        // Bitmap sized for a different participant count is rejected outright.
+        let oversized = EcdsaCertificate {
+            signers: Signers::from(5, signers.clone()),
+            signatures: certificate.signatures.clone(),
+        };
+        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &oversized,
+            &Sequential,
+        ));
+        let undersized = EcdsaCertificate {
+            signers: Signers::from(3, signers),
+            signatures: certificate.signatures,
+        };
+        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            &mut rng,
+            &subject,
+            &undersized,
+            &Sequential,
+        ));
+    }
+
+    // (d) Certificate codec round-trip with the bounded config.
+    #[test]
+    fn certificate_codec_roundtrip() {
+        let (schemes, verifier) = setup(4);
+        let subject = item(6, b"codec");
+        let attestations = sign_all(&schemes, &subject, 3);
+        let certificate = verifier
+            .assemble::<_, N3f1>(attestations, &Sequential)
+            .unwrap();
+
+        let encoded = certificate.encode();
+        let decoded =
+            EcdsaCertificate::decode_cfg(encoded.clone(), &verifier.certificate_codec_config())
+                .expect("decode certificate");
+        assert_eq!(decoded, certificate);
+
+        // The unbounded (journal) config also decodes it.
+        let decoded_unbounded = EcdsaCertificate::decode_cfg(
+            encoded.clone(),
+            &EcdsaScheme::certificate_codec_config_unbounded(),
+        )
+        .expect("decode certificate unbounded");
+        assert_eq!(decoded_unbounded, certificate);
+
+        // A tighter bound than the actual bitmap is rejected.
+        assert!(EcdsaCertificate::decode_cfg(encoded, &2).is_err());
+
+        // Certificates with no signers are rejected at decode time.
+        let empty = EcdsaCertificate {
+            signers: Signers::from(4, std::iter::empty::<Participant>()),
+            signatures: Vec::new(),
+        };
+        assert!(EcdsaCertificate::decode_cfg(empty.encode(), &4).is_err());
+
+        // A corrupted signature (0xff-filled: invalid parity byte) fails decode,
+        // not verification.
+        let mut corrupt = certificate.encode_mut();
+        let len = corrupt.len();
+        corrupt[len - 65..].fill(0xff);
+        assert!(EcdsaCertificate::decode_cfg(corrupt.freeze(), &4).is_err());
+
+        // A truncated signature list fails decode.
+        let mut truncated = certificate.encode_mut();
+        let len = truncated.len();
+        truncated.truncate(len - 65);
+        assert!(EcdsaCertificate::decode_cfg(truncated.freeze(), &4).is_err());
+    }
+
+    // (e) ON-CHAIN PARITY ANCHOR. This is the on-chain compatibility guarantee:
+    // - the scheme's attestation signature bytes equal the low-level
+    //   `sign_digest` bytes for a fixed key (65-byte r||s||v, v in {27,28}, low-s);
+    // - every certificate signature recovers to its bitmap participant's address
+    //   via Ethereum's prehash recovery — exactly the `ecrecover(msgHash, v, r, s)`
+    //   an on-chain verifier evaluates.
+    // If this test breaks, certificates will no longer verify on-chain. Do not
+    // "fix" it by changing the preimage.
+    #[test]
+    fn onchain_parity_anchor() {
+        let keys: Vec<Ecdsa> = ["101", "202", "303", "404"]
+            .iter()
+            .map(|k| get_signer(k))
+            .collect();
+        let participants: Set<PublicKey> = keys
+            .iter()
+            .map(|k| k.public_key())
+            .try_collect()
+            .expect("distinct keys");
+
+        let mut hasher = Sha256::new();
+        hasher.update(b"fixed on-chain task digest");
+        let digest = hasher.finalize();
+        let digest_bytes: [u8; 32] = digest.as_ref().try_into().unwrap();
+        let subject = Item {
+            height: Height::new(77),
+            digest,
+        };
+
+        // 1. Attestation signature bytes == low-level raw digest signature bytes.
+        let mut schemes: Vec<EcdsaScheme> = keys
+            .iter()
+            .map(|k| EcdsaScheme::signer(participants.clone(), k.private_key()).unwrap())
+            .collect();
+        schemes.sort_by_key(|s| s.me().unwrap());
+        for key in &keys {
+            let scheme = schemes
+                .iter()
+                .find(|s| s.participants().key(s.me().unwrap()) == Some(&key.public_key()))
+                .unwrap();
+            let attestation = scheme.sign::<Sha256Digest>(&subject).unwrap();
+            let low_level = key.sign_digest(&digest_bytes);
+            assert_eq!(
+                attestation.signature.get().unwrap().as_ref(),
+                low_level.as_ref(),
+                "scheme signature must be bit-identical to Ecdsa::sign_digest"
+            );
+        }
+
+        // 2. Every certificate signature recovers to its participant's address —
+        // exactly the ecrecover check an on-chain verifier evaluates.
+        let quorum_schemes = &schemes[..3];
+        let attestations: Vec<_> = quorum_schemes
+            .iter()
+            .map(|s| s.sign::<Sha256Digest>(&subject).unwrap())
+            .collect();
+        let certificate = schemes[0]
+            .assemble::<_, N3f1>(attestations, &Sequential)
+            .unwrap();
+
+        let verifier = EcdsaScheme::verifier(participants.clone());
+        let addresses = verifier.signer_addresses(&certificate.signers);
+        assert_eq!(addresses.len(), 3);
+        for (address, signature) in addresses.iter().zip(&certificate.signatures) {
+            assert_eq!(
+                signature.recover(&digest_bytes),
+                Some(*address),
+                "certificate signature must ecrecover to the bitmap participant"
+            );
+            let raw = signature.as_ref();
+            assert!(raw[64] == 27 || raw[64] == 28, "v must be 27/28 on-chain");
+        }
+
+        // 3. The participant order (and thus the signature order) is ascending by
+        // address — the strictly-ascending-signers order an on-chain verifier
+        // typically enforces to reject duplicate signers.
+        let mut sorted = addresses.clone();
+        sorted.sort();
+        assert_eq!(addresses, sorted);
+    }
+
+    // (f) Engine-integration smoke test through the aggregation types. Proves the
+    // blanket `aggregation::scheme::Scheme<D>` marker holds for EcdsaScheme (the
+    // same entry points the engine uses: Ack::sign / Ack::verify /
+    // Certificate::from_acks / Certificate::verify with M = N3f1).
+    #[test]
+    fn aggregation_engine_smoke() {
+        let mut rng = test_rng();
+        let (schemes, verifier) = setup(4);
+        let subject = item(11, b"engine smoke");
+
+        let acks: Vec<Ack<EcdsaScheme, Sha256Digest>> = schemes
+            .iter()
+            .map(|s| Ack::sign(s, Epoch::zero(), subject.clone()).expect("participant signs"))
+            .collect();
+        for ack in &acks {
+            assert!(ack.verify(&mut rng, &verifier, &Sequential));
+        }
+
+        // Verifier-only schemes cannot produce acks.
+        assert!(Ack::sign(&verifier, Epoch::zero(), subject.clone()).is_none());
+
+        let certificate =
+            AggCertificate::from_acks(&verifier, &acks, &Sequential).expect("quorum of acks");
+        assert_eq!(certificate.item, subject);
+        assert!(certificate.verify(&mut rng, &verifier, &Sequential));
+
+        // Below-quorum ack sets do not form a certificate.
+        assert!(AggCertificate::from_acks(&verifier, &acks[..2], &Sequential).is_none());
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bn254;
 pub mod consensus;
+pub mod ecdsa;
 pub mod validator;
 pub mod wire;

--- a/examples/counter/node/src/app.rs
+++ b/examples/counter/node/src/app.rs
@@ -347,7 +347,7 @@ pub fn main() {
         }
 
         // Reporter actor: certificate/tip accounting + TaskBook pruning.
-        let (node_reporter, reporter_mailbox) = NodeReporter::new(
+        let (node_reporter, reporter_mailbox) = NodeReporter::<_, Bn254Scheme>::new(
             context.child("reporter"),
             task_book_mailbox.clone(),
             Arc::clone(&engine_tip),

--- a/examples/counter/router/src/app.rs
+++ b/examples/counter/router/src/app.rs
@@ -332,7 +332,7 @@ pub fn main() {
                 scheme.participants().iter().cloned().collect();
             let tip_reports = tip_reports.clone();
             context.child("tip_reports").spawn(move |_| async move {
-                ingest_tip_reports::<CounterTaskData, _>(
+                ingest_tip_reports::<CounterTaskData, _, _>(
                     directive_receiver,
                     participant_keys,
                     tip_reports,

--- a/examples/counter/router/src/factories.rs
+++ b/examples/counter/router/src/factories.rs
@@ -54,7 +54,7 @@ pub async fn create_task_source() -> Result<CounterTaskSource> {
 pub async fn create_submitter(
     scheme: Bn254Scheme,
     assignments: SharedAssignments<CounterTaskData>,
-    certified: CertifiedReceiver,
+    certified: CertifiedReceiver<Bn254Scheme>,
     resolutions: ResolutionSender,
     namespace: Vec<u8>,
 ) -> Result<Submitter<CounterTaskData, CounterHandler>> {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -40,6 +40,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
@@ -49,4 +50,5 @@ prost-build = { workspace = true }
 
 [dev-dependencies]
 commonware-avs-core = { path = "../core", features = ["test-utils"] }
+commonware-parallel = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/node/src/reporter.rs
+++ b/node/src/reporter.rs
@@ -10,11 +10,11 @@
 //! [`TaskBook`]: crate::task_book::TaskBook
 
 use commonware_actor::{Feedback, mailbox};
-use commonware_avs_core::bn254::Bn254Scheme;
 use commonware_avs_core::consensus::PRUNE_SLACK;
 use commonware_avs_core::wire::{TaskData, skip_digest};
 use commonware_consensus::Reporter;
 use commonware_consensus::aggregation::types::Activity;
+use commonware_cryptography::certificate::Scheme;
 use commonware_cryptography::sha256::Digest;
 use commonware_runtime::Metrics;
 use commonware_runtime::telemetry::metrics::{Counter, Gauge, GaugeExt as _, raw};
@@ -32,9 +32,9 @@ const MAILBOX_CAPACITY: usize = 1024;
 /// Activities reported by the engine, wrapped so the overflow policy can be
 /// implemented locally (never drop: a lost `Certified` would undercount and a
 /// lost `Tip` could stall TaskBook pruning until the next fast-forward).
-struct Report(Activity<Bn254Scheme, Digest>);
+struct Report<S: Scheme>(Activity<S, Digest>);
 
-impl mailbox::Policy for Report {
+impl<S: Scheme> mailbox::Policy for Report<S> {
     type Overflow = VecDeque<Self>;
 
     fn handle(overflow: &mut VecDeque<Self>, message: Self) {
@@ -44,12 +44,12 @@ impl mailbox::Policy for Report {
 
 /// Handle given to the engine (`Config::reporter`). Cheap to clone.
 #[derive(Clone)]
-pub struct ReporterMailbox {
-    sender: mailbox::Sender<Report>,
+pub struct ReporterMailbox<S: Scheme> {
+    sender: mailbox::Sender<Report<S>>,
 }
 
-impl Reporter for ReporterMailbox {
-    type Activity = Activity<Bn254Scheme, Digest>;
+impl<S: Scheme> Reporter for ReporterMailbox<S> {
+    type Activity = Activity<S, Digest>;
 
     /// Enqueues the activity for the actor; never blocks (the engine calls this
     /// inline from its event loop and during journal replay).
@@ -59,8 +59,8 @@ impl Reporter for ReporterMailbox {
 }
 
 /// Actor that consumes reported activities.
-pub struct NodeReporter<T: TaskData + PartialEq> {
-    mailbox: mailbox::Receiver<Report>,
+pub struct NodeReporter<T: TaskData + PartialEq, S: Scheme> {
+    mailbox: mailbox::Receiver<Report<S>>,
     /// Prunes resolved directives as the engine's tip advances.
     task_book: TaskBookMailbox<T>,
     /// Application namespace bound into [`skip_digest`], matching the namespace
@@ -85,7 +85,7 @@ pub struct NodeReporter<T: TaskData + PartialEq> {
     skipped_counter: Counter,
 }
 
-impl<T: TaskData + PartialEq> NodeReporter<T> {
+impl<T: TaskData + PartialEq, S: Scheme> NodeReporter<T, S> {
     /// Creates the actor and the mailbox handle to wire into the engine config.
     ///
     /// `context` labels the mailbox and metrics in the runtime registry;
@@ -97,7 +97,7 @@ impl<T: TaskData + PartialEq> NodeReporter<T> {
         task_book: TaskBookMailbox<T>,
         tip_handle: Arc<AtomicU64>,
         namespace: Vec<u8>,
-    ) -> (Self, ReporterMailbox) {
+    ) -> (Self, ReporterMailbox<S>) {
         let height_gauge = context.register(
             "height",
             "highest aggregation height observed via certificate or tip",
@@ -150,7 +150,6 @@ impl<T: TaskData + PartialEq> NodeReporter<T> {
                         info!(
                             height,
                             digest = ?certificate.item.digest,
-                            signers = certificate.certificate.signers.count(),
                             "height certified"
                         );
                     }

--- a/node/src/reporter.rs
+++ b/node/src/reporter.rs
@@ -7,6 +7,12 @@
 //! tracks the highest observed height for metrics, and drives [`TaskBook`]
 //! pruning so directive state does not grow without bound.
 //!
+//! Applications whose schemes need post-certification work run their own actor
+//! beside this one and opt in to a certificate tap
+//! ([`NodeReporter::with_certificate_tap`]): the reporter then forwards one
+//! [`CertificateObservation`] per certified height to that consumer, deduplicated
+//! across journal replays exactly like its own counters.
+//!
 //! [`TaskBook`]: crate::task_book::TaskBook
 
 use commonware_actor::{Feedback, mailbox};
@@ -22,6 +28,7 @@ use commonware_utils::NZUsize;
 use std::collections::{BTreeSet, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, info, trace};
 
 use crate::task_book::TaskBookMailbox;
@@ -58,9 +65,38 @@ impl<S: Scheme> Reporter for ReporterMailbox<S> {
     }
 }
 
+/// A certificate observation forwarded to an application-side consumer (e.g. an
+/// actor running scheme-specific post-certification work). Sent once per height,
+/// deduplicated across journal replays exactly like the reporter's own counters.
+#[derive(Clone, Debug)]
+pub struct CertificateObservation<S: Scheme> {
+    /// The aggregation height the certificate covers.
+    pub height: u64,
+    /// The certified digest — either a task's expected payload hash or
+    /// `skip_digest(namespace, height)`. Skip heights are forwarded like any
+    /// other; the consumer filters.
+    pub digest: Digest,
+    /// The scheme's certificate as assembled by the engine.
+    pub certificate: S::Certificate,
+}
+
+pub type ObservationSender<S> = UnboundedSender<CertificateObservation<S>>;
+pub type ObservationReceiver<S> = UnboundedReceiver<CertificateObservation<S>>;
+
+/// Channel carrying certificate observations from the reporter to an
+/// application-side consumer (see [`NodeReporter::with_certificate_tap`]).
+pub fn observation_channel<S: Scheme>() -> (ObservationSender<S>, ObservationReceiver<S>) {
+    tokio::sync::mpsc::unbounded_channel()
+}
+
 /// Actor that consumes reported activities.
 pub struct NodeReporter<T: TaskData + PartialEq, S: Scheme> {
     mailbox: mailbox::Receiver<Report<S>>,
+    /// Optional certificate tap: one [`CertificateObservation`] per certified
+    /// height (first observation only — journal replays are deduplicated),
+    /// skip-digest heights included. `None` unless the application opted in via
+    /// [`Self::with_certificate_tap`].
+    tap: Option<ObservationSender<S>>,
     /// Prunes resolved directives as the engine's tip advances.
     task_book: TaskBookMailbox<T>,
     /// Application namespace bound into [`skip_digest`], matching the namespace
@@ -117,6 +153,7 @@ impl<T: TaskData + PartialEq, S: Scheme> NodeReporter<T, S> {
         (
             Self {
                 mailbox: receiver,
+                tap: None,
                 task_book,
                 namespace,
                 tip_handle,
@@ -127,6 +164,17 @@ impl<T: TaskData + PartialEq, S: Scheme> NodeReporter<T, S> {
             },
             ReporterMailbox { sender },
         )
+    }
+
+    /// Opts in to certificate observation: every certified height — including
+    /// skip-digest heights, which the consumer filters — is forwarded to `tap`
+    /// exactly once (journal replays are deduplicated by height). A dropped
+    /// receiver is logged at debug and never affects the reporter's own
+    /// accounting.
+    #[must_use]
+    pub fn with_certificate_tap(mut self, tap: ObservationSender<S>) -> Self {
+        self.tap = Some(tap);
+        self
     }
 
     /// Runs until the engine (all mailbox handles) is gone.
@@ -142,16 +190,26 @@ impl<T: TaskData + PartialEq, S: Scheme> NodeReporter<T, S> {
                         continue;
                     }
                     self.certified_counter.inc();
-                    let skipped = certificate.item.digest == skip_digest(&self.namespace, height);
+                    let digest = certificate.item.digest;
+                    let skipped = digest == skip_digest(&self.namespace, height);
                     if skipped {
                         self.skipped_counter.inc();
                         debug!(height, "height certified as skipped");
                     } else {
-                        info!(
+                        info!(height, digest = ?digest, "height certified");
+                    }
+                    if let Some(tap) = &self.tap {
+                        // Forwarded for every certified height, skip digests
+                        // included — the consumer filters. A gone receiver only
+                        // costs the observation, never the accounting above.
+                        let observation = CertificateObservation {
                             height,
-                            digest = ?certificate.item.digest,
-                            "height certified"
-                        );
+                            digest,
+                            certificate: certificate.certificate,
+                        };
+                        if tap.send(observation).is_err() {
+                            debug!(height, "certificate tap receiver gone; observation dropped");
+                        }
                     }
                     self.advance(height);
                 }
@@ -186,5 +244,233 @@ impl<T: TaskData + PartialEq, S: Scheme> NodeReporter<T, S> {
             self.task_book.prune_below(floor);
             self.certified = self.certified.split_off(&floor);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task_book::TaskBook;
+    use bytes::{Buf, BufMut};
+    use commonware_avs_core::bn254::{Bn254, Bn254Scheme, G1PublicKey, PublicKey};
+    use commonware_codec::{EncodeSize, Error, Read, Write};
+    use commonware_consensus::aggregation::types::{Ack, Certificate, Item};
+    use commonware_consensus::types::{Epoch, Height};
+    use commonware_cryptography::{Hasher, Sha256, Signer};
+    use commonware_parallel::Sequential;
+    use commonware_runtime::{Clock, Runner, Spawner, Supervisor, deterministic};
+    use commonware_utils::TryCollect;
+    use commonware_utils::ordered::Set;
+    use std::time::Duration;
+
+    /// Namespace bound into skip digests for every reporter under test.
+    const NAMESPACE: &[u8] = b"reporter-test";
+
+    /// Minimal task payload satisfying [`TaskData`] without any
+    /// application-specific dependencies (the reporter never inspects it; it only
+    /// types the TaskBook mailbox).
+    #[derive(Debug, Clone, PartialEq)]
+    struct TestTask;
+
+    impl Write for TestTask {
+        fn write(&self, _: &mut impl BufMut) {}
+    }
+
+    impl Read for TestTask {
+        type Cfg = ();
+
+        fn read_cfg(_: &mut impl Buf, _: &()) -> Result<Self, Error> {
+            Ok(Self)
+        }
+    }
+
+    impl EncodeSize for TestTask {
+        fn encode_size(&self) -> usize {
+            0
+        }
+    }
+
+    /// Deterministic signer set with participant-ordered schemes, mirroring
+    /// `core::bn254::scheme::tests::setup`.
+    fn setup(n: usize) -> (Vec<Bn254Scheme>, Bn254Scheme) {
+        let keys: Vec<Bn254> = (0..n).map(|i| Bn254::from_seed(i as u64)).collect();
+        let participants: Set<PublicKey> = keys
+            .iter()
+            .map(|k| k.public_key())
+            .try_collect()
+            .expect("no duplicate keys");
+        let g1_keys: Vec<G1PublicKey> = participants
+            .iter()
+            .map(|pk| {
+                keys.iter()
+                    .find(|k| &k.public_key() == pk)
+                    .expect("participant derives from keys")
+                    .public_g1()
+            })
+            .collect();
+
+        let mut schemes: Vec<Bn254Scheme> = keys
+            .iter()
+            .map(|k| {
+                Bn254Scheme::signer(participants.clone(), g1_keys.clone(), k.private_key())
+                    .expect("key is in participant set")
+            })
+            .collect();
+        schemes.sort_by_key(|s| s.me().expect("signer scheme has an index"));
+        let verifier = Bn254Scheme::verifier(participants, g1_keys);
+        (schemes, verifier)
+    }
+
+    fn item(height: u64, payload: &[u8]) -> Item<Digest> {
+        let mut hasher = Sha256::new();
+        hasher.update(payload);
+        Item {
+            height: Height::new(height),
+            digest: hasher.finalize(),
+        }
+    }
+
+    fn certify_item(
+        schemes: &[Bn254Scheme],
+        verifier: &Bn254Scheme,
+        subject: Item<Digest>,
+    ) -> Certificate<Bn254Scheme, Digest> {
+        let acks: Vec<Ack<Bn254Scheme, Digest>> = schemes
+            .iter()
+            .map(|s| Ack::sign(s, Epoch::zero(), subject.clone()).expect("participant signs"))
+            .collect();
+        Certificate::from_acks(verifier, &acks, &Sequential).expect("quorum of acks")
+    }
+
+    fn certify(
+        schemes: &[Bn254Scheme],
+        verifier: &Bn254Scheme,
+        height: u64,
+        payload: &[u8],
+    ) -> Certificate<Bn254Scheme, Digest> {
+        certify_item(schemes, verifier, item(height, payload))
+    }
+
+    /// Drives a fresh `NodeReporter` (tap installed) and its TaskBook inside the
+    /// deterministic runtime, handing `f` the context, the engine-side mailbox,
+    /// the tap receiver, and the shared tip handle.
+    fn with_reporter<F, Fut>(f: F)
+    where
+        F: FnOnce(
+                deterministic::Context,
+                ReporterMailbox<Bn254Scheme>,
+                ObservationReceiver<Bn254Scheme>,
+                Arc<AtomicU64>,
+            ) -> Fut
+            + Send
+            + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (task_book, task_book_mailbox) =
+                TaskBook::<TestTask>::new(context.child("task_book"));
+            context
+                .child("task_book_actor")
+                .spawn(move |_| task_book.run());
+            let tip_handle = Arc::new(AtomicU64::new(0));
+            let (tap, received) = observation_channel();
+            let (reporter, mailbox) = NodeReporter::<TestTask, Bn254Scheme>::new(
+                context.child("reporter"),
+                task_book_mailbox,
+                Arc::clone(&tip_handle),
+                NAMESPACE.to_vec(),
+            );
+            let reporter = reporter.with_certificate_tap(tap);
+            context
+                .child("reporter_actor")
+                .spawn(move |_| reporter.run());
+            f(context, mailbox, received, tip_handle).await;
+        });
+    }
+
+    #[test]
+    fn certified_activity_reaches_tap() {
+        let (schemes, verifier) = setup(4);
+        let certificate = certify(&schemes, &verifier, 2, b"task payload");
+        let skip_item = Item {
+            height: Height::new(3),
+            digest: skip_digest(NAMESPACE, 3),
+        };
+        let skip_certificate = certify_item(&schemes, &verifier, skip_item.clone());
+
+        with_reporter(
+            move |_context, mut mailbox, mut received, _tip| async move {
+                mailbox.report(Activity::Certified(certificate.clone()));
+                mailbox.report(Activity::Certified(skip_certificate.clone()));
+
+                let observation = received.recv().await.expect("observation forwarded");
+                assert_eq!(observation.height, 2);
+                assert_eq!(observation.digest, certificate.item.digest);
+                assert_eq!(observation.certificate, certificate.certificate);
+
+                // Skip-digest heights are forwarded like any other; the consumer
+                // filters.
+                let skipped = received.recv().await.expect("skip observation forwarded");
+                assert_eq!(skipped.height, 3);
+                assert_eq!(skipped.digest, skip_item.digest);
+                assert_eq!(skipped.certificate, skip_certificate.certificate);
+            },
+        );
+    }
+
+    #[test]
+    fn replayed_certificate_not_resent() {
+        let (schemes, verifier) = setup(4);
+        let certificate = certify(&schemes, &verifier, 5, b"replayed task");
+        let later = certify(&schemes, &verifier, 6, b"later task");
+
+        with_reporter(
+            move |_context, mut mailbox, mut received, _tip| async move {
+                mailbox.report(Activity::Certified(certificate.clone()));
+                // Journal replay after restart re-reports the same height.
+                mailbox.report(Activity::Certified(certificate.clone()));
+                mailbox.report(Activity::Certified(later.clone()));
+
+                let first = received.recv().await.expect("first observation forwarded");
+                assert_eq!(first.height, 5);
+                // The mailbox and the tap are both FIFO, so the observation after
+                // height 5 being height 6 proves the replay was not re-sent.
+                let second = received.recv().await.expect("later observation forwarded");
+                assert_eq!(second.height, 6);
+                assert!(received.try_recv().is_err());
+            },
+        );
+    }
+
+    #[test]
+    fn dropped_receiver_does_not_break_reporter() {
+        let (schemes, verifier) = setup(4);
+        let first = certify(&schemes, &verifier, 1, b"first task");
+        let second = certify(&schemes, &verifier, 2, b"second task");
+
+        with_reporter(
+            move |context, mut mailbox, received, tip_handle| async move {
+                drop(received);
+                mailbox.report(Activity::Certified(first));
+                mailbox.report(Activity::Certified(second));
+
+                // No tap to synchronize on: poll the shared tip handle, which the
+                // reporter raises after each certificate it accounts for.
+                for _ in 0..100 {
+                    if tip_handle.load(Ordering::Relaxed) >= 2 {
+                        break;
+                    }
+                    context.sleep(Duration::from_millis(10)).await;
+                }
+                assert_eq!(tip_handle.load(Ordering::Relaxed), 2);
+                // The counter advanced past the dead tap for both heights.
+                let metrics = context.encode();
+                assert!(
+                    metrics.contains("certified_total 2"),
+                    "expected certified_total 2 in:\n{metrics}"
+                );
+            },
+        );
     }
 }

--- a/node/src/task_book.rs
+++ b/node/src/task_book.rs
@@ -34,10 +34,10 @@
 //! dropped, keeping the first-recorded directive.
 
 use commonware_actor::mailbox;
-use commonware_avs_core::bn254::PublicKey;
 use commonware_avs_core::consensus::PRUNE_SLACK;
 use commonware_avs_core::wire::{TaskData, TaskDirective};
 use commonware_codec::{DecodeExt, Encode};
+use commonware_cryptography::PublicKey;
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::Metrics;
 use commonware_utils::NZUsize;
@@ -341,18 +341,19 @@ fn beyond_window(height: u64, tip: u64, window: u64) -> bool {
 /// TipReport (the directive isn't below tip) and no error anywhere else, so it is
 /// logged here via a rate-limited `warn!` — observability only; the directive is
 /// still delivered to the TaskBook exactly as any other.
-pub async fn ingest<T, R, S>(
+pub async fn ingest<T, P, R, S>(
     mut receiver: R,
     mut sender: S,
-    router: PublicKey,
+    router: P,
     task_book: TaskBookMailbox<T>,
     engine_tip: Arc<AtomicU64>,
     window: u64,
     min_report_interval: Duration,
 ) where
     T: TaskData + PartialEq,
-    R: Receiver<PublicKey = PublicKey>,
-    S: Sender<PublicKey = PublicKey>,
+    P: PublicKey,
+    R: Receiver<PublicKey = P>,
+    S: Sender<PublicKey = P>,
 {
     let mut last_report: Option<Instant> = None;
     let mut last_beyond_window_warning: Option<Instant> = None;

--- a/router/src/ecdsa_submitter.rs
+++ b/router/src/ecdsa_submitter.rs
@@ -1,0 +1,406 @@
+//! Submitter: turns certified heights into on-chain ECDSA verification calls.
+//!
+//! Consumes certificate observations from the [`crate::reporter::CertReporter`] and
+//! resolves each one:
+//!
+//! - `skip_digest(namespace, height)`: the quorum abandoned the height — log and
+//!   notify the sequencer ([`ResolutionKind::Skipped`]); nothing goes on-chain.
+//! - No assignment, or a digest that matches neither the assignment nor the skip
+//!   digest: pre-restart leftovers — log and notify ([`ResolutionKind::Foreign`]);
+//!   the sequencer re-assigns any in-flight task.
+//! - Expected digest: pair the certificate's signer bitmap with its per-signer
+//!   ECDSA signatures, sort by ascending operator address (the order an on-chain
+//!   verifier typically enforces to reject duplicate signers), pin a reference
+//!   block, and call [`EcdsaVerificationHandler::handle_verification`], with
+//!   bounded retries.
+//!
+//! Unlike the BN254 flow ([`crate::submitter`]), no registry reads are needed to
+//! resolve signers: [`EcdsaScheme::signer_addresses`] maps the certificate's bitmap
+//! straight to Ethereum addresses locally. The only on-chain read before submission
+//! is therefore a single L1 `eth_blockNumber` call — the certificate itself already
+//! carries the operators' 65-byte `r || s || v` signatures.
+
+use crate::executor::ExecutionResult;
+use crate::reporter::{CertifiedHeight, CertifiedReceiver};
+use crate::sequencer::{Resolution, ResolutionKind, ResolutionSender, SharedAssignments};
+use alloy_primitives::{Address, Bytes, FixedBytes};
+use alloy_provider::Provider;
+use anyhow::Result;
+use commonware_avs_bindings::ReadOnlyProvider;
+use commonware_avs_core::ecdsa::{EcdsaCertificate, EcdsaScheme};
+use commonware_avs_core::wire::{TaskData, skip_digest};
+use commonware_cryptography::sha256::Digest;
+use std::time::Duration;
+use tracing::{error, info, warn};
+
+/// Retries after the first failed submission attempt.
+const MAX_RETRIES: u32 = 2;
+
+/// Delay before the first retry; doubles per attempt.
+const INITIAL_RETRY_BACKOFF: Duration = Duration::from_secs(2);
+
+/// Contract-specific handler for a certified task's on-chain ECDSA signature check.
+///
+/// The submitter has already resolved the certificate's signer bitmap to operator
+/// addresses (ascending order) and paired each with its raw 65-byte signature. This
+/// trait is the seam where an application submits (or simulates) the actual
+/// transaction against its own contract bindings.
+///
+/// `reference_block_number` is the L1 block number observed via a single
+/// `eth_blockNumber` call immediately before this handler runs. It is passed
+/// through unmodified — it is NOT decremented here. A handler that simulates the
+/// transaction with `eth_estimateGas` (which runs against the *current* block) and
+/// needs a strictly-past block for a registry checkpoint lookup should compute
+/// `reference_block_number - 1` itself, mirroring the split used by the
+/// implementation this trait was ported from.
+#[async_trait::async_trait]
+pub trait EcdsaVerificationHandler: Send + Sync {
+    /// The application's task payload type, carried by [`commonware_avs_core::wire::TaskDirective`].
+    type TaskData: TaskData;
+
+    /// Submits (or otherwise executes) the verification for `height`.
+    ///
+    /// `task_data` is `Some` for a task the submitter announced and `None` for a
+    /// certified height with no known assignment (pre-restart leftovers observed
+    /// purely from the certificate stream).
+    async fn handle_verification(
+        &mut self,
+        height: u64,
+        msg_hash: FixedBytes<32>,
+        reference_block_number: u64,
+        operators: Vec<Address>,
+        signatures: Vec<Bytes>,
+        task_data: Option<&Self::TaskData>,
+    ) -> Result<ExecutionResult>;
+}
+
+/// Consumes certified heights and drives the on-chain submission.
+pub struct Submitter<T, H>
+where
+    T: TaskData,
+    H: EcdsaVerificationHandler<TaskData = T>,
+{
+    /// Verifier scheme: maps certificate signer bitmaps to operator addresses.
+    scheme: EcdsaScheme,
+    /// L1 read-side provider: supplies the reference block passed to the handler
+    /// (operator state for an EigenLayer-style registry lives on L1 only).
+    view_only_provider: ReadOnlyProvider,
+    /// Executes the final on-chain verification transaction.
+    handler: H,
+    /// Height → expected digest + task, written by the sequencer.
+    assignments: SharedAssignments<T>,
+    /// Verified certificates from the reporter.
+    certified: CertifiedReceiver<EcdsaScheme>,
+    /// Final dispositions back to the sequencer.
+    resolutions: ResolutionSender,
+    /// Application namespace bound into [`skip_digest`], matching the namespace
+    /// the sequencer uses for the same deployment.
+    namespace: Vec<u8>,
+}
+
+impl<T, H> Submitter<T, H>
+where
+    T: TaskData,
+    H: EcdsaVerificationHandler<TaskData = T>,
+{
+    pub fn new(
+        scheme: EcdsaScheme,
+        view_only_provider: ReadOnlyProvider,
+        handler: H,
+        assignments: SharedAssignments<T>,
+        certified: CertifiedReceiver<EcdsaScheme>,
+        resolutions: ResolutionSender,
+        namespace: Vec<u8>,
+    ) -> Self {
+        Self {
+            scheme,
+            view_only_provider,
+            handler,
+            assignments,
+            certified,
+            resolutions,
+            namespace,
+        }
+    }
+
+    /// Runs until the reporter side of the certified channel closes.
+    pub async fn run(mut self) {
+        while let Some(certified) = self.certified.recv().await {
+            self.handle_certified(certified).await;
+        }
+        info!("certified channel closed; submitter exiting");
+    }
+
+    /// Notifies the sequencer of a height's final disposition.
+    fn notify(&self, height: u64, kind: ResolutionKind) {
+        if self.resolutions.send(Resolution { height, kind }).is_err() {
+            // The sequencer is gone; the process is shutting down.
+            warn!(height, "resolution channel closed");
+        }
+    }
+
+    async fn handle_certified(&mut self, certified: CertifiedHeight<EcdsaScheme>) {
+        let CertifiedHeight {
+            height,
+            digest,
+            certificate,
+        } = certified;
+
+        // Skip certificate: the quorum abandoned the height.
+        if digest == skip_digest(&self.namespace, height) {
+            info!(height, "skip certificate observed; nothing to submit");
+            self.notify(height, ResolutionKind::Skipped);
+            return;
+        }
+
+        // Look up the sequencer's assignment for this height.
+        let assignment = match self.assignments.read() {
+            Ok(assignments) => assignments.get(&height).cloned(),
+            Err(_) => {
+                error!(height, "assignments lock poisoned; treating as unassigned");
+                None
+            }
+        };
+        let Some(assignment) = assignment else {
+            // Unassigned heights certify during journal replay (pre-restart
+            // leftovers) or when nodes resolved a height from a previous router
+            // life. There is nothing to submit — the task cache is gone.
+            info!(
+                height,
+                digest = %digest,
+                "certificate for unassigned height; nothing to submit"
+            );
+            self.notify(height, ResolutionKind::Foreign);
+            return;
+        };
+        if assignment.digest != digest {
+            // A certificate formed for a digest we did not announce (a pre-restart
+            // leftover): the height is consumed, the in-flight task is not.
+            warn!(
+                height,
+                expected = %assignment.digest,
+                certified = %digest,
+                "certificate digest does not match assignment; height consumed"
+            );
+            self.notify(height, ResolutionKind::Foreign);
+            return;
+        }
+
+        // Expected digest: submit on-chain with bounded retries. Failures here
+        // are either transient RPC issues (retry helps) or deterministic
+        // rejections (retries burn two extra round-trips, then the height is
+        // released as a failed execution).
+        let mut backoff = INITIAL_RETRY_BACKOFF;
+        let mut attempt = 0u32;
+        loop {
+            attempt += 1;
+            match self
+                .submit(height, digest, &certificate, &assignment.task)
+                .await
+            {
+                Ok(result) => {
+                    info!(
+                        height,
+                        tx = %result.transaction_hash,
+                        block = ?result.block_number,
+                        status = ?result.status,
+                        "verification submitted"
+                    );
+                    let success = result.status.unwrap_or(true);
+                    self.notify(height, ResolutionKind::Executed { success });
+                    return;
+                }
+                Err(error) if attempt <= MAX_RETRIES => {
+                    warn!(
+                        height,
+                        attempt,
+                        max_retries = MAX_RETRIES,
+                        %error,
+                        backoff_secs = backoff.as_secs_f64(),
+                        "submission failed; retrying"
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff *= 2;
+                }
+                Err(error) => {
+                    error!(
+                        height,
+                        attempts = attempt,
+                        %error,
+                        "submission failed after retries; releasing height"
+                    );
+                    self.notify(height, ResolutionKind::Executed { success: false });
+                    return;
+                }
+            }
+        }
+    }
+
+    /// One end-to-end submission attempt for a certified task digest.
+    async fn submit(
+        &mut self,
+        height: u64,
+        digest: Digest,
+        certificate: &EcdsaCertificate,
+        task: &T,
+    ) -> Result<ExecutionResult> {
+        // Bitmap → operator addresses, in participant order. The certificate was
+        // verified by the reporter, so the bitmap length matches the set and the
+        // signature list is index-aligned with the bitmap's ascending iteration.
+        let (operators, signatures) = ordered_signatures(&self.scheme, certificate)?;
+
+        let msg_hash = FixedBytes::<32>::from_slice(digest.as_ref());
+
+        // The reference block handed to the handler. Fetched once, unmodified —
+        // see the handler trait doc for who is responsible for any `- 1` split.
+        let reference_block_number = self
+            .view_only_provider
+            .get_block_number()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get block number: {}", e))?;
+
+        info!(
+            height,
+            signers = signatures.len(),
+            reference_block = reference_block_number,
+            "submitting ECDSA quorum certificate"
+        );
+
+        self.handler
+            .handle_verification(
+                height,
+                msg_hash,
+                reference_block_number,
+                operators,
+                signatures,
+                Some(task),
+            )
+            .await
+    }
+}
+
+/// Pairs a verified certificate's signer bitmap with its signatures and returns
+/// the raw 65-byte signatures sorted by ascending signer address — the order an
+/// on-chain verifier typically enforces to reject duplicate signers.
+///
+/// Participant order (the certificate's signature order) is already ascending by
+/// address bytes, so this sort is a no-op in practice; it stays as a defensive
+/// guarantee of the on-chain calling convention rather than an assumption about
+/// the participant set's ordering.
+fn ordered_signatures(
+    scheme: &EcdsaScheme,
+    certificate: &EcdsaCertificate,
+) -> Result<(Vec<Address>, Vec<Bytes>)> {
+    let addresses = scheme.signer_addresses(&certificate.signers);
+    if addresses.is_empty() || addresses.len() != certificate.signatures.len() {
+        return Err(anyhow::anyhow!(
+            "signer bitmap resolved to an inconsistent signer set ({} addresses / {} signatures)",
+            addresses.len(),
+            certificate.signatures.len()
+        ));
+    }
+
+    let mut pairs: Vec<_> = addresses
+        .into_iter()
+        .zip(certificate.signatures.iter())
+        .collect();
+    pairs.sort_by_key(|(address, _)| *address);
+
+    Ok(pairs
+        .into_iter()
+        .map(|(address, signature)| (address, Bytes::copy_from_slice(signature.as_ref())))
+        .unzip())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_avs_core::ecdsa::{Ecdsa, PublicKey};
+    use commonware_consensus::aggregation::types::Item;
+    use commonware_consensus::types::Height;
+    use commonware_cryptography::certificate::Scheme as _;
+    use commonware_cryptography::{Hasher as _, Sha256, Signer as _};
+    use commonware_parallel::Sequential;
+    use commonware_utils::ordered::Set;
+    use commonware_utils::{N3f1, TryCollect};
+
+    /// Builds a 4-participant scheme set plus a verifier, participant-ordered.
+    fn setup() -> (Vec<Ecdsa>, EcdsaScheme) {
+        let keys: Vec<Ecdsa> = (0..4).map(Ecdsa::from_seed).collect();
+        let participants: Set<PublicKey> = keys
+            .iter()
+            .map(|k| k.public_key())
+            .try_collect()
+            .expect("distinct keys");
+        let verifier = EcdsaScheme::verifier(participants);
+        (keys, verifier)
+    }
+
+    fn certificate_for(
+        keys: &[Ecdsa],
+        verifier: &EcdsaScheme,
+        payload: &[u8],
+    ) -> (EcdsaCertificate, [u8; 32]) {
+        let mut hasher = Sha256::new();
+        hasher.update(payload);
+        let digest = hasher.finalize();
+        let digest_bytes: [u8; 32] = digest.as_ref().try_into().unwrap();
+        let subject = Item {
+            height: Height::new(1),
+            digest,
+        };
+
+        let schemes: Vec<EcdsaScheme> = keys
+            .iter()
+            .map(|k| EcdsaScheme::signer(verifier.participants().clone(), k.private_key()).unwrap())
+            .collect();
+        let attestations: Vec<_> = schemes
+            .iter()
+            .take(3)
+            .map(|s| {
+                s.sign::<commonware_cryptography::sha256::Digest>(&subject)
+                    .unwrap()
+            })
+            .collect();
+        let certificate = verifier
+            .assemble::<_, N3f1>(attestations, &Sequential)
+            .unwrap();
+        (certificate, digest_bytes)
+    }
+
+    #[test]
+    fn ordered_signatures_are_ascending_and_recover_to_operators() {
+        let (keys, verifier) = setup();
+        let (certificate, digest) = certificate_for(&keys, &verifier, b"submitter ordering");
+
+        let (signers, signatures) = ordered_signatures(&verifier, &certificate).unwrap();
+        assert_eq!(signers.len(), 3);
+        assert_eq!(signatures.len(), 3);
+
+        // Recovered signer addresses match the operator list positionally, are
+        // strictly ascending, and every signer is one of the operators.
+        let operators: Vec<Address> = verifier
+            .participants()
+            .iter()
+            .map(|k| k.address())
+            .collect();
+        let mut last = Address::ZERO;
+        for (operator, raw) in signers.iter().zip(&signatures) {
+            let sig = commonware_avs_core::ecdsa::Signature::try_from(raw.as_ref()).unwrap();
+            let recovered = sig.recover(&digest).unwrap();
+            assert_eq!(recovered, *operator, "signature must be index-aligned");
+            assert!(recovered > last, "signers must be strictly ascending");
+            assert!(operators.contains(&recovered), "signer must be an operator");
+            last = recovered;
+        }
+    }
+
+    #[test]
+    fn ordered_signatures_rejects_count_mismatch() {
+        let (keys, verifier) = setup();
+        let (mut certificate, _) = certificate_for(&keys, &verifier, b"count mismatch");
+        certificate.signatures.pop();
+
+        assert!(ordered_signatures(&verifier, &certificate).is_err());
+    }
+}

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod automaton;
+pub mod ecdsa_submitter;
 pub mod executor;
 pub mod reporter;
 pub mod sequencer;

--- a/router/src/reporter.rs
+++ b/router/src/reporter.rs
@@ -15,11 +15,12 @@
 //! pre-restart heights.
 
 use commonware_actor::{Feedback, mailbox};
-use commonware_avs_core::bn254::{Bn254Certificate, Bn254Scheme};
 use commonware_avs_core::consensus::PRUNE_SLACK;
 use commonware_consensus::Reporter;
+use commonware_consensus::aggregation::scheme::Scheme as AggregationScheme;
 use commonware_consensus::aggregation::types::{Activity, Certificate};
 use commonware_consensus::types::Height;
+use commonware_cryptography::certificate::Scheme;
 use commonware_cryptography::sha256::Digest;
 use commonware_parallel::Sequential;
 use commonware_runtime::Metrics;
@@ -32,23 +33,30 @@ use tracing::{debug, error, info, trace, warn};
 
 /// A certificate observation handed to the height's consumer.
 #[derive(Clone, Debug)]
-pub struct CertifiedHeight {
+pub struct CertifiedHeight<S: Scheme> {
     /// The aggregation height the certificate covers.
     pub height: u64,
     /// The certified digest — either a task's expected payload hash or
     /// `skip_digest(height)`.
     pub digest: Digest,
-    /// The BN254 certificate (signer bitmap + aggregated G1 signature) as
-    /// assembled by the engine and re-verified by this reporter.
-    pub certificate: Bn254Certificate,
+    /// The scheme's certificate as assembled by the engine and re-verified by
+    /// this reporter.
+    pub certificate: S::Certificate,
 }
 
-pub type CertifiedSender = UnboundedSender<CertifiedHeight>;
-pub type CertifiedReceiver = UnboundedReceiver<CertifiedHeight>;
+pub type CertifiedSender<S> = UnboundedSender<CertifiedHeight<S>>;
+pub type CertifiedReceiver<S> = UnboundedReceiver<CertifiedHeight<S>>;
 
 /// Channel carrying verified certificates from the reporter to their consumer.
-pub fn certified_channel() -> (CertifiedSender, CertifiedReceiver) {
+pub fn certified_channel<S: Scheme>() -> (CertifiedSender<S>, CertifiedReceiver<S>) {
     tokio::sync::mpsc::unbounded_channel()
+}
+
+/// Read-only view of certificate progress used by the sequencer: the next height
+/// needing a certificate, and the certified digest for a height (if observed).
+pub trait CertIndex: Clone + Send + 'static {
+    fn get_tip(&self) -> impl Future<Output = u64> + Send;
+    fn get(&self, height: u64) -> impl Future<Output = Option<Digest>> + Send;
 }
 
 /// Mailbox capacity before messages spill to the unbounded overflow queue.
@@ -58,9 +66,9 @@ pub fn certified_channel() -> (CertifiedSender, CertifiedReceiver) {
 const MAILBOX_CAPACITY: usize = 1024;
 
 /// Messages processed by the [`CertReporter`] actor.
-enum Message {
+enum Message<S: Scheme> {
     /// A newly assembled (or replayed) certificate from the engine.
-    Certified(Certificate<Bn254Scheme, Digest>),
+    Certified(Certificate<S, Digest>),
     /// A tip fast-forward from the engine.
     Tip(Height),
     /// Query: the next height the engine needs a certificate for.
@@ -69,7 +77,7 @@ enum Message {
     Get(u64, oneshot::Sender<Option<Digest>>),
 }
 
-impl mailbox::Policy for Message {
+impl<S: Scheme> mailbox::Policy for Message<S> {
     type Overflow = VecDeque<Self>;
 
     fn handle(overflow: &mut VecDeque<Self>, message: Self) {
@@ -82,12 +90,12 @@ impl mailbox::Policy for Message {
 /// Handle for reporting to and querying the [`CertReporter`] actor. Cheap to
 /// clone; the clone handed to the engine is its `Reporter`.
 #[derive(Clone)]
-pub struct CertReporterMailbox {
-    sender: mailbox::Sender<Message>,
+pub struct CertReporterMailbox<S: Scheme> {
+    sender: mailbox::Sender<Message<S>>,
 }
 
-impl Reporter for CertReporterMailbox {
-    type Activity = Activity<Bn254Scheme, Digest>;
+impl<S: Scheme> Reporter for CertReporterMailbox<S> {
+    type Activity = Activity<S, Digest>;
 
     fn report(&mut self, activity: Self::Activity) -> Feedback {
         match activity {
@@ -102,11 +110,11 @@ impl Reporter for CertReporterMailbox {
     }
 }
 
-impl CertReporterMailbox {
+impl<S: Scheme> CertIndex for CertReporterMailbox<S> {
     /// Returns the engine's observed tip: the next height needing a certificate
     /// (max of reported tips and `certified height + 1`). `0` until the engine
     /// reports anything, or when the actor is gone (shutdown).
-    pub async fn get_tip(&self) -> u64 {
+    async fn get_tip(&self) -> u64 {
         let (responder, receiver) = oneshot::channel();
         if !self.sender.enqueue(Message::GetTip(responder)).accepted() {
             warn!("cert reporter closed; tip query unanswered");
@@ -117,7 +125,7 @@ impl CertReporterMailbox {
 
     /// Returns the certified digest for `height`, if a certificate was observed
     /// (and not yet pruned). `None` when the actor is gone.
-    pub async fn get(&self, height: u64) -> Option<Digest> {
+    async fn get(&self, height: u64) -> Option<Digest> {
         let (responder, receiver) = oneshot::channel();
         if !self
             .sender
@@ -133,25 +141,27 @@ impl CertReporterMailbox {
 
 /// Actor owning the certificate log. The context doubles as the RNG for the
 /// defensive certificate re-verification.
-pub struct CertReporter<E>
+pub struct CertReporter<E, S>
 where
     E: Metrics + CryptoRngCore + Send + 'static,
+    S: AggregationScheme<Digest>,
 {
     context: E,
-    mailbox: mailbox::Receiver<Message>,
+    mailbox: mailbox::Receiver<Message<S>>,
     /// Verifier scheme (`me() == None`) used to re-verify certificates.
-    scheme: Bn254Scheme,
+    scheme: S,
     /// Certified digest per height: dedupe (replay-idempotency) + query source.
     certified: BTreeMap<u64, Digest>,
-    /// Next height the engine needs a certificate for (see [`CertReporterMailbox::get_tip`]).
+    /// Next height the engine needs a certificate for (see [`CertIndex::get_tip`]).
     tip: u64,
     /// Verified certificates bound for the height's consumer.
-    submit: CertifiedSender,
+    submit: CertifiedSender<S>,
 }
 
-impl<E> CertReporter<E>
+impl<E, S> CertReporter<E, S>
 where
     E: Metrics + CryptoRngCore + Send + 'static,
+    S: AggregationScheme<Digest>,
 {
     /// Creates the actor and its mailbox handle.
     ///
@@ -159,9 +169,9 @@ where
     /// `scheme` must be the same verifier instance the engine runs with.
     pub fn new(
         context: E,
-        scheme: Bn254Scheme,
-        submit: CertifiedSender,
-    ) -> (Self, CertReporterMailbox) {
+        scheme: S,
+        submit: CertifiedSender<S>,
+    ) -> (Self, CertReporterMailbox<S>) {
         let (sender, receiver) = mailbox::new(context.child("mailbox"), NZUsize!(MAILBOX_CAPACITY));
         (
             Self {
@@ -193,7 +203,7 @@ where
         info!("cert reporter mailbox closed; exiting");
     }
 
-    fn handle_certified(&mut self, certificate: Certificate<Bn254Scheme, Digest>) {
+    fn handle_certified(&mut self, certificate: Certificate<S, Digest>) {
         let height = certificate.item.height.get();
         let digest = certificate.item.digest;
 
@@ -265,10 +275,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_avs_core::bn254::{Bn254, G1PublicKey, PublicKey};
+    use commonware_avs_core::bn254::{Bn254, Bn254Scheme, G1PublicKey, PublicKey};
     use commonware_consensus::aggregation::types::{Ack, Item};
     use commonware_consensus::types::Epoch;
-    use commonware_cryptography::certificate::Scheme;
     use commonware_cryptography::{Hasher, Sha256, Signer};
     use commonware_runtime::{Runner, Spawner, Supervisor, deterministic};
     use commonware_utils::TryCollect;
@@ -333,7 +342,9 @@ mod tests {
     /// mailbox and a raw `CertifiedReceiver` to `f`.
     fn with_reporter<F, Fut>(scheme: Bn254Scheme, f: F)
     where
-        F: FnOnce(CertReporterMailbox, CertifiedReceiver) -> Fut + Send + 'static,
+        F: FnOnce(CertReporterMailbox<Bn254Scheme>, CertifiedReceiver<Bn254Scheme>) -> Fut
+            + Send
+            + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
         let executor = deterministic::Runner::default();

--- a/router/src/sequencer.rs
+++ b/router/src/sequencer.rs
@@ -25,10 +25,10 @@
 //! certificates) are resolved by the nodes' auto-skip rule once they see this
 //! router's first directive for a higher height.
 
-use crate::reporter::CertReporterMailbox;
-use commonware_avs_core::bn254::PublicKey;
+use crate::reporter::CertIndex;
 use commonware_avs_core::wire::{TaskData, TaskDirective};
 use commonware_codec::{DecodeExt, Encode};
+use commonware_cryptography::PublicKey;
 use commonware_cryptography::sha256::Digest;
 use commonware_p2p::{Receiver as NetworkReceiver, Recipients, Sender as NetworkSender};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -179,14 +179,14 @@ enum HeightOutcome {
 /// Callers must only [`TipReports::record`] reports from authenticated quorum
 /// participants (see [`ingest_tip_reports`]).
 #[derive(Clone)]
-pub struct TipReports {
+pub struct TipReports<P: PublicKey> {
     /// Highest tip reported per participant (monotonic).
-    reports: Arc<RwLock<BTreeMap<PublicKey, u64>>>,
+    reports: Arc<RwLock<BTreeMap<P, u64>>>,
     /// Faults tolerated by the engine's N3f1 quorum rule.
     max_faults: usize,
 }
 
-impl TipReports {
+impl<P: PublicKey> TipReports<P> {
     pub fn new(participant_count: usize) -> Self {
         Self {
             reports: Arc::new(RwLock::new(BTreeMap::new())),
@@ -195,7 +195,7 @@ impl TipReports {
     }
 
     /// Records `tip` for `peer`, keeping the per-peer maximum.
-    pub fn record(&self, peer: PublicKey, tip: u64) {
+    pub fn record(&self, peer: P, tip: u64) {
         if let Ok(mut reports) = self.reports.write() {
             let entry = reports.entry(peer).or_insert(0);
             *entry = (*entry).max(tip);
@@ -219,13 +219,14 @@ impl TipReports {
 /// Only quorum participants may influence the sequencer's height choice; other
 /// directive variants (the router's own broadcasts echoed back by a buggy peer)
 /// are ignored. Malformed payloads are logged and dropped.
-pub async fn ingest_tip_reports<T, R>(
+pub async fn ingest_tip_reports<T, P, R>(
     mut receiver: R,
-    participants: HashSet<PublicKey>,
-    reports: TipReports,
+    participants: HashSet<P>,
+    reports: TipReports<P>,
 ) where
     T: TaskData,
-    R: NetworkReceiver<PublicKey = PublicKey>,
+    P: PublicKey,
+    R: NetworkReceiver<PublicKey = P>,
 {
     loop {
         match receiver.recv().await {
@@ -259,10 +260,12 @@ pub async fn ingest_tip_reports<T, R>(
 }
 
 /// Pulls tasks from the application and drives one aggregation height at a time.
-pub struct Sequencer<T, S, TS>
+pub struct Sequencer<T, P, S, R, TS>
 where
     T: TaskData,
-    S: NetworkSender<PublicKey = PublicKey>,
+    P: PublicKey,
+    S: NetworkSender<PublicKey = P>,
+    R: CertIndex,
     TS: TaskSource<T>,
 {
     source: TS,
@@ -271,7 +274,7 @@ where
     /// Shared with the automaton and submitter.
     assignments: SharedAssignments<T>,
     /// Certificate observations (tip + per-height digests) from the engine.
-    reporter: CertReporterMailbox,
+    reporter: R,
     /// Final dispositions from the submitter.
     resolutions: ResolutionReceiver,
     /// Broadcasts [`TaskDirective`]s to the nodes on the directive p2p channel.
@@ -284,19 +287,21 @@ where
     /// send side (its inbound-heavy directive-channel usage never warms it),
     /// silently dropping every `Announce`. Addressing the known operator set
     /// directly bypasses that snapshot.
-    recipients: Vec<PublicKey>,
+    recipients: Vec<P>,
     /// Node tip reports; a safe tip above the driven height supersedes it.
-    tip_reports: TipReports,
+    tip_reports: TipReports<P>,
     /// Next height to assign; only advances when the current height resolves.
     next_height: u64,
     round_timeout: Duration,
     rebroadcast_interval: Duration,
 }
 
-impl<T, S, TS> Sequencer<T, S, TS>
+impl<T, P, S, R, TS> Sequencer<T, P, S, R, TS>
 where
     T: TaskData,
-    S: NetworkSender<PublicKey = PublicKey>,
+    P: PublicKey,
+    S: NetworkSender<PublicKey = P>,
+    R: CertIndex,
     TS: TaskSource<T>,
 {
     #[allow(clippy::too_many_arguments)]
@@ -304,11 +309,11 @@ where
         source: TS,
         dispatch_time: DispatchTime,
         assignments: SharedAssignments<T>,
-        reporter: CertReporterMailbox,
+        reporter: R,
         resolutions: ResolutionReceiver,
         directive_sender: S,
-        recipients: Vec<PublicKey>,
-        tip_reports: TipReports,
+        recipients: Vec<P>,
+        tip_reports: TipReports<P>,
         round_timeout: Duration,
         rebroadcast_interval: Duration,
     ) -> Self {

--- a/router/src/submitter.rs
+++ b/router/src/submitter.rs
@@ -85,7 +85,7 @@ where
     /// Height → expected digest + task, written by the sequencer.
     assignments: SharedAssignments<T>,
     /// Verified certificates from the reporter.
-    certified: CertifiedReceiver,
+    certified: CertifiedReceiver<Bn254Scheme>,
     /// Final dispositions back to the sequencer.
     resolutions: ResolutionSender,
     /// Application namespace bound into [`skip_digest`], matching the namespace
@@ -113,7 +113,7 @@ where
         registry_coordinator_address: Address,
         handler: H,
         assignments: SharedAssignments<T>,
-        certified: CertifiedReceiver,
+        certified: CertifiedReceiver<Bn254Scheme>,
         resolutions: ResolutionSender,
         namespace: Vec<u8>,
         quorum_numbers: Bytes,
@@ -150,7 +150,7 @@ where
         }
     }
 
-    async fn handle_certified(&mut self, certified: CertifiedHeight) {
+    async fn handle_certified(&mut self, certified: CertifiedHeight<Bn254Scheme>) {
         let CertifiedHeight {
             height,
             digest,


### PR DESCRIPTION
## Summary

Stacked on #184. Makes the aggregation actor chassis generic over the certificate scheme and p2p identity, adds an ECDSA (secp256k1) scheme alongside BN254, and exposes the seams an application-side scheme needs to plug in — deliberately **without** shipping scheme-specific operational machinery in the library.

Informed by gas-killer/service#312 and gas-killer/service#314 (aggregate Schnorr): the library's job is to *allow* a variety of schemes, not to guarantee every scheme's tooling. Schemes that are pure single-shot `certificate::Scheme` implementations ship in `core` as batteries; anything needing infrastructure beside the engine (nonce registries, spend journals, completion rounds) stays in the application, consuming the generic hooks added here.

## Changes

- **Chassis genericization**: `CertReporter<E, S>` / `CertifiedHeight<S>` / `NodeReporter<T, S>` over `S: certificate::Scheme`; new `CertIndex` trait (`get_tip`/`get`) decoupling the sequencer from the concrete reporter — `Sequencer<T, P, S, R: CertIndex, TS>`; identity-generic `ingest`/`TipReports<P>`/recipients. Matches the trait shapes the service converged on, so its migration to the library stays mechanical.
- **ECDSA scheme** (`core::ecdsa`): operator's Ethereum key = p2p identity (20-byte address) = signing key; canonical low-s 65-byte signatures enforced at decode; `EcdsaCertificate` = signer bitmap + per-signer signatures in participant order. `EcdsaSubmitter` + `EcdsaVerificationHandler` seam hand `(operators[], signatures[])` to the application (e.g. ERC-1271 stake-registry verification). No new bindings needed.
- **Certificate taps**: node-side `CertificateObservation<S>` opt-in channel (`NodeReporter::with_certificate_tap`), replay-deduplicated, carrying the opaque `S::Certificate` — the hook an application-side actor (e.g. a Schnorr completion round) consumes; router-side observation was already generic via `CertifiedHeight<S>`.
- **README**: documents the pluggable-scheme architecture and the app-side extension path.

BN254 remains fully supported and is the counter example's scheme — the example needed only type-annotation changes, demonstrating the genericization is behavior-preserving.

## Validation

`cargo check --workspace --all-targets`, 83 tests (workspace, all passing), `clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --check` — all clean. New test coverage: full EcdsaScheme suite (quorum boundaries, tampered certificates, codec, ordering), tap delivery/replay-dedupe/dropped-receiver tests on the deterministic runtime.